### PR TITLE
Add CRC32C and update UByteBuffer

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Network/CRC32C.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/CRC32C.cpp
@@ -1,0 +1,18 @@
+#include "Network/CRC32C.h"
+
+static const uint32 Polynomial = 0x82F63B78u;
+
+uint32 FCRC32C::Compute(const uint8* Data, int32 Length)
+{
+    uint32 Crc = 0xFFFFFFFFu;
+    for (int32 i = 0; i < Length; ++i)
+    {
+        Crc ^= Data[i];
+        for (int j = 0; j < 8; ++j)
+        {
+            uint32 Mask = -(int32)(Crc & 1);
+            Crc = (Crc >> 1) ^ (Polynomial & Mask);
+        }
+    }
+    return ~Crc;
+}

--- a/Unreal/Source/ToS_Network/Public/Network/CRC32C.h
+++ b/Unreal/Source/ToS_Network/Public/Network/CRC32C.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FCRC32C
+{
+public:
+    static const uint32 ChecksumSize = 4;
+
+    static uint32 Compute(const uint8* Data, int32 Length);
+    static uint32 Compute(const TArray<uint8>& Data)
+    {
+        return Compute(Data.GetData(), Data.Num());
+    }
+};

--- a/Unreal/Source/ToS_Network/Public/Network/UByteBuffer.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UByteBuffer.h
@@ -49,8 +49,10 @@ public:
 
 	UByteBuffer* WriteUInt16(uint16 Value);
 
-	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
-	UByteBuffer* WriteInt32(int32 Value);
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        UByteBuffer* WriteInt32(int32 Value);
+
+        UByteBuffer* WriteUInt32(uint32 Value);
 
 	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
 	UByteBuffer* WriteInt64(int64 Value);
@@ -67,8 +69,11 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
 	UByteBuffer* WriteFVector(const FVector& Value);
 
-	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
-	UByteBuffer* WriteFRotator(const FRotator& Value);
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        UByteBuffer* WriteFRotator(const FRotator& Value);
+
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        void WriteSign();
 
 	// Read
 
@@ -77,8 +82,10 @@ public:
 
 	uint16 ReadUInt16();
 
-	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
-	int32 ReadInt32();
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        int32 ReadInt32();
+
+        uint32 ReadUInt32();
 
 	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
 	int64 ReadInt64();
@@ -95,13 +102,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
 	FVector ReadFVector();
 
-	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
-	FRotator ReadFRotator();
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        FRotator ReadFRotator();
+
+        uint32 ReadSign();
 
 	// Utility
 
-	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
-	void Reset();
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        void Reset();
+
+        UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
+        void ResetOffset();
 
 	UFUNCTION(BlueprintCallable, Category = "ByteBuffer")
 	FString ToHex() const;


### PR DESCRIPTION
## Summary
- implement missing functions on `UByteBuffer`
- add a `CRC32C` utility for packet signing
- support writing CRC signature in `UByteBuffer`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bed2a2eb48333a9c504d8e93657e6