### PR TITLE
Add memory profiler utilities

### DIFF
--- a/Core/Diagnostics/MemoryUsageLogger.cs
+++ b/Core/Diagnostics/MemoryUsageLogger.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Diagnostics;
+
+public static class MemoryUsageLogger
+{
+    public static void Log(string prefix = "")
+    {
+        long managed = GC.GetTotalMemory(false);
+        long privateBytes = Process.GetCurrentProcess().PrivateMemorySize64;
+        var stats = ByteBufferPool.GetStats();
+        Console.WriteLine($"[Memory]{prefix} Managed: {managed / (1024 * 1024)}MB " +
+                          $"Private: {privateBytes / (1024 * 1024)}MB " +
+                          $"BuffersCreated: {stats.created} InPool: {stats.pooled} InUse: {stats.created - stats.pooled}");
+    }
+}

--- a/Core/Network/UDPServer.cs
+++ b/Core/Network/UDPServer.cs
@@ -570,6 +570,7 @@ public sealed class UDPServer
         Stopwatch sw = new Stopwatch();
         sw.Start();
         double lastTime = sw.Elapsed.TotalMilliseconds;
+        Stopwatch memLog = Stopwatch.StartNew();
 
         while (Running)
         {
@@ -578,6 +579,12 @@ public sealed class UDPServer
             lastTime = now;
 
             Update((float)(delta / 1000.0));
+
+            if (memLog.Elapsed >= TimeSpan.FromSeconds(10))
+            {
+                MemoryUsageLogger.Log();
+                memLog.Restart();
+            }
 
             double elapsed = sw.Elapsed.TotalMilliseconds - now;
             int sleep = (int)(targetFrameTime - elapsed);


### PR DESCRIPTION
## Summary
- add `MemoryUsageLogger` to print managed, private memory usage
- track buffer counts in `ByteBufferPool`
- periodically log memory stats from `UDPServer`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c0c14248c8333aa447af1ece7c6f6