### PR TITLE
Refactor UDP send queue to avoid ByteBuffer allocations

### DIFF
--- a/Core/Network/QueueStructLinked.cs
+++ b/Core/Network/QueueStructLinked.cs
@@ -1,0 +1,82 @@
+public class QueueStructLinked<T>
+{
+    public class Node
+    {
+        public T Value;
+        public Node Next;
+
+        public Node(T value)
+        {
+            Value = value;
+        }
+    }
+
+    public Node Head;
+    public Node Tail;
+
+    public void Add(T item)
+    {
+        var node = new Node(item);
+        node.Next = Head;
+        if (Tail == null)
+            Tail = node;
+        Head = node;
+    }
+
+    public Node Clear()
+    {
+        var result = Head;
+        Head = null;
+        Tail = null;
+        return result;
+    }
+
+    public Node Take()
+    {
+        if (Head == null)
+            return null;
+
+        var result = Head;
+        if (Head == Tail)
+        {
+            Head = null;
+            Tail = null;
+        }
+        else
+        {
+            Head = Head.Next;
+        }
+        return result;
+    }
+
+    public int Length
+    {
+        get
+        {
+            int val = 0;
+            var current = Head;
+            while (current != null)
+            {
+                current = current.Next;
+                ++val;
+            }
+            return val;
+        }
+    }
+
+    public void Merge(QueueStructLinked<T> other)
+    {
+        if (Head == null)
+        {
+            Head = other.Head;
+            Tail = other.Tail;
+        }
+        else if (other.Head != null)
+        {
+            Tail.Next = other.Head;
+            Tail = other.Tail;
+        }
+        other.Head = null;
+        other.Tail = null;
+    }
+}

--- a/Core/Network/SendPacket.cs
+++ b/Core/Network/SendPacket.cs
@@ -1,0 +1,8 @@
+using System.Net;
+
+public struct SendPacket
+{
+    public byte[] Buffer;
+    public int Length;
+    public EndPoint Address;
+}


### PR DESCRIPTION
## Summary
- create a simple `SendPacket` struct storing the byte array and destination
- implement generic `QueueStructLinked` to queue structs
- refactor `UDPServer` to use `SendPacket` queues instead of `ByteBuffer`
- update send logic and background send thread for the new format
- add CRC32 signature helper used by `Send` methods

## Testing
- `dotnet build GameServer.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d33e268508333a166daf351b26a61