### PR TITLE
Implement native buffer pooling for sending

### DIFF
--- a/Core/Network/NativeBuffer.cs
+++ b/Core/Network/NativeBuffer.cs
@@ -1,0 +1,11 @@
+public unsafe struct NativeBuffer
+{
+    public byte* Data;
+    public int Length;
+
+    public NativeBuffer(byte* data, int length)
+    {
+        Data = data;
+        Length = length;
+    }
+}

--- a/Core/Network/QueueBuffer.cs
+++ b/Core/Network/QueueBuffer.cs
@@ -22,6 +22,8 @@
  */
 
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using System.Buffers;
 
 public class QueueBuffer
 {
@@ -66,6 +68,17 @@ public class QueueBuffer
     public static void AddBuffer(uint socketId, byte[] buffer)
     {
 
+    }
+
+    public unsafe static void AddBuffer(uint socketId, NativeBuffer buffer)
+    {
+        byte[] managed = ArrayPool<byte>.Shared.Rent(buffer.Length);
+        Marshal.Copy((IntPtr)buffer.Data, managed, 0, buffer.Length);
+        NativeMemory.Free(buffer.Data);
+
+        var bb = ByteBufferPool.Acquire();
+        bb.Assign(managed, buffer.Length);
+        AddBuffer(socketId, bb);
     }
 
     public static void CheckAndSend(uint socketId)


### PR DESCRIPTION
## Summary
- use ArrayPool in `UDPSocket.Send(NativeBuffer)` to avoid new allocations
- pool buffers in `QueueBuffer.AddBuffer(NativeBuffer)`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3ba684848333bca071cd034cf79f