### PR TITLE
Add missing unit tests

### DIFF
--- a/Tests/Engine/FRotator.test.cs
+++ b/Tests/Engine/FRotator.test.cs
@@ -1,0 +1,56 @@
+namespace Tests
+{
+    public class FRotatorTests : AbstractTest
+    {
+        public FRotatorTests()
+        {
+            Describe("FRotator", () =>
+            {
+                It("should normalize angles", () =>
+                {
+                    var r = new FRotator(370, -190, 720);
+                    r.Normalize();
+                    Expect(r.Pitch).ToBe(10f);
+                    Expect(r.Yaw).ToBe(170f);
+                    Expect(r.Roll).ToBe(0f);
+                });
+
+                It("should add and subtract", () =>
+                {
+                    var a = new FRotator(10, 20, 30);
+                    var b = new FRotator(1, 2, 3);
+                    var sum = a + b;
+                    var diff = a - b;
+                    Expect(sum.Pitch).ToBe(11f);
+                    Expect(sum.Yaw).ToBe(22f);
+                    Expect(sum.Roll).ToBe(33f);
+                    Expect(diff.Pitch).ToBe(9f);
+                    Expect(diff.Yaw).ToBe(18f);
+                    Expect(diff.Roll).ToBe(27f);
+                });
+
+                It("should multiply and divide", () =>
+                {
+                    var r = new FRotator(10, 20, 30);
+                    var mul = r * 2f;
+                    var div = r / 2f;
+                    Expect(mul.Pitch).ToBe(20f);
+                    Expect(mul.Yaw).ToBe(40f);
+                    Expect(mul.Roll).ToBe(60f);
+                    Expect(div.Pitch).ToBe(5f);
+                    Expect(div.Yaw).ToBe(10f);
+                    Expect(div.Roll).ToBe(15f);
+                });
+
+                It("should compare equality", () =>
+                {
+                    var a = new FRotator(1, 2, 3);
+                    var b = new FRotator(1, 2, 3);
+                    var c = new FRotator(0, 0, 0);
+                    Expect(a == b).ToBe(true);
+                    Expect(a != c).ToBe(true);
+                });
+            });
+        }
+    }
+}

--- a/Tests/Engine/FVector.test.cs
+++ b/Tests/Engine/FVector.test.cs
@@ -1,0 +1,70 @@
+namespace Tests
+{
+    public class FVectorTests : AbstractTest
+    {
+        public FVectorTests()
+        {
+            Describe("FVector", () =>
+            {
+                It("should compute size and squared size", () =>
+                {
+                    var v = new FVector(3, 4, 0);
+                    Expect(v.Size()).ToBeApproximately(5f);
+                    Expect(v.SizeSquared()).ToBeApproximately(25f);
+                });
+
+                It("should normalize vector", () =>
+                {
+                    var v = new FVector(3, 0, 0);
+                    v.Normalize();
+                    Expect(v.X).ToBe(1f);
+                    Expect(v.Y).ToBe(0f);
+                    Expect(v.Z).ToBe(0f);
+                });
+
+                It("should compute dot and cross products", () =>
+                {
+                    var a = new FVector(1, 2, 3);
+                    var b = new FVector(4, 5, 6);
+                    var dot = FVector.Dot(a, b);
+                    var cross = FVector.Cross(new FVector(1, 0, 0), new FVector(0, 1, 0));
+                    Expect(dot).ToBe(32f);
+                    Expect(cross.X).ToBe(0f);
+                    Expect(cross.Y).ToBe(0f);
+                    Expect(cross.Z).ToBe(1f);
+                });
+
+                It("should support arithmetic operators", () =>
+                {
+                    var a = new FVector(1, 2, 3);
+                    var b = new FVector(4, 5, 6);
+                    var sum = a + b;
+                    var diff = b - a;
+                    var mul = a * 2f;
+                    var div = b / 2f;
+                    Expect(sum.X).ToBe(5f);
+                    Expect(sum.Y).ToBe(7f);
+                    Expect(sum.Z).ToBe(9f);
+                    Expect(diff.X).ToBe(3f);
+                    Expect(diff.Y).ToBe(3f);
+                    Expect(diff.Z).ToBe(3f);
+                    Expect(mul.X).ToBe(2f);
+                    Expect(mul.Y).ToBe(4f);
+                    Expect(mul.Z).ToBe(6f);
+                    Expect(div.X).ToBe(2f);
+                    Expect(div.Y).ToBe(2.5f);
+                    Expect(div.Z).ToBe(3f);
+                });
+
+                It("should compare equality", () =>
+                {
+                    var a = new FVector(1, 2, 3);
+                    var b = new FVector(1, 2, 3);
+                    var c = new FVector(3, 2, 1);
+                    Expect(a == b).ToBe(true);
+                    Expect(a != c).ToBe(true);
+                });
+            });
+        }
+    }
+}

--- a/Tests/Integrity/IntegritySystem.test.cs
+++ b/Tests/Integrity/IntegritySystem.test.cs
@@ -1,0 +1,34 @@
+using System.IO;
+
+namespace Tests
+{
+    public class IntegritySystemTests : AbstractTest
+    {
+        public IntegritySystemTests()
+        {
+            Describe("IntegritySystem", () =>
+            {
+                It("should generate and load integrity table", () =>
+                {
+                    string projectDir = IntegritySystem.GetProjectDirectory();
+                    string packageJson = Path.Combine(projectDir, "package.json");
+                    string unreal = Path.Combine(projectDir, "Unreal");
+                    string tables = Path.Combine(projectDir, "Tables");
+
+                    if (Directory.Exists(tables))
+                        Directory.Delete(tables, true);
+
+                    IntegritySystem.InitializeIntegrityTable(packageJson, unreal);
+                    bool result = IntegritySystem.GetCurrentTable(out var table);
+
+                    Expect(result).ToBeTrue();
+                    Expect(table).NotToBeNull();
+                    Expect(table.KeyCount).ToBeGreaterThan(0);
+
+                    if (Directory.Exists(tables))
+                        Directory.Delete(tables, true);
+                });
+            });
+        }
+    }
+}

--- a/Tests/Utils/ObjectPool.test.cs
+++ b/Tests/Utils/ObjectPool.test.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Tests
+{
+    class PoolableItem : IPoolable
+    {
+        public bool ResetCalled { get; private set; }
+
+        public void Reset()
+        {
+            ResetCalled = true;
+        }
+    }
+
+    public class ObjectPoolTests : AbstractTest
+    {
+        public ObjectPoolTests()
+        {
+            Describe("ObjectPool", () =>
+            {
+                It("should rent new object when pool is empty", () =>
+                {
+                    var pool = new ObjectPool<PoolableItem>();
+                    var item = pool.Rent();
+                    Expect(item).NotToBeNull();
+                });
+
+                It("should reuse returned object", () =>
+                {
+                    var pool = new ObjectPool<PoolableItem>();
+                    var item1 = pool.Rent();
+                    pool.Return(item1);
+                    var item2 = pool.Rent();
+                    Expect(ReferenceEquals(item1, item2)).ToBeTrue();
+                    Expect(item2.ResetCalled).ToBeTrue();
+                });
+
+                It("should handle multiple objects", () =>
+                {
+                    var pool = new ObjectPool<PoolableItem>();
+                    var first = pool.Rent();
+                    var second = pool.Rent();
+                    pool.Return(first);
+                    pool.Return(second);
+                    var a = pool.Rent();
+                    var b = pool.Rent();
+                    Expect((ReferenceEquals(first, a) || ReferenceEquals(first, b))).ToBeTrue();
+                    Expect((ReferenceEquals(second, a) || ReferenceEquals(second, b))).ToBeTrue();
+                });
+            });
+        }
+    }
+}

--- a/Tests/Utils/QueueStructLinked.test.cs
+++ b/Tests/Utils/QueueStructLinked.test.cs
@@ -1,0 +1,78 @@
+namespace Tests
+{
+    public class QueueStructLinkedTests : AbstractTest
+    {
+        public QueueStructLinkedTests()
+        {
+            Describe("QueueStructLinked", () =>
+            {
+                It("should add items and maintain head and tail", () =>
+                {
+                    var queue = new QueueStructLinked<int>();
+                    queue.Add(1);
+                    Expect(queue.Head.Value).ToBe(1);
+                    Expect(queue.Tail.Value).ToBe(1);
+                    Expect(queue.Length).ToBe(1);
+
+                    queue.Add(2);
+                    Expect(queue.Head.Value).ToBe(2);
+                    Expect(queue.Tail.Value).ToBe(1);
+                    Expect(queue.Length).ToBe(2);
+                });
+
+                It("should take items in order", () =>
+                {
+                    var queue = new QueueStructLinked<int>();
+                    queue.Add(1);
+                    queue.Add(2);
+
+                    var n1 = queue.Take();
+                    Expect(n1.Value).ToBe(2);
+                    Expect(queue.Length).ToBe(1);
+
+                    var n2 = queue.Take();
+                    Expect(n2.Value).ToBe(1);
+                    Expect(queue.Length).ToBe(0);
+                });
+
+                It("should clear items", () =>
+                {
+                    var queue = new QueueStructLinked<int>();
+                    queue.Add(1);
+                    queue.Add(2);
+                    var oldHead = queue.Clear();
+                    Expect(oldHead.Value).ToBe(2);
+                    Expect(queue.Head).ToBeNull();
+                    Expect(queue.Tail).ToBeNull();
+                    Expect(queue.Length).ToBe(0);
+                });
+
+                It("should merge queues", () =>
+                {
+                    var q1 = new QueueStructLinked<int>();
+                    q1.Add(1);
+                    q1.Add(2);
+
+                    var q2 = new QueueStructLinked<int>();
+                    q2.Add(3);
+                    q2.Add(4);
+
+                    q1.Merge(q2);
+                    Expect(q1.Length).ToBe(4);
+                    Expect(q2.Length).ToBe(0);
+
+                    var r1 = q1.Take();
+                    var r2 = q1.Take();
+                    var r3 = q1.Take();
+                    var r4 = q1.Take();
+
+                    Expect(r1.Value).ToBe(2);
+                    Expect(r2.Value).ToBe(1);
+                    Expect(r3.Value).ToBe(4);
+                    Expect(r4.Value).ToBe(3);
+                    Expect(q1.Length).ToBe(0);
+                });
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ObjectPool tests covering reuse and reset behavior
- test QueueStructLinked add/take/clear/merge
- verify IntegritySystem initializes and loads table
- add FRotator arithmetic and normalization tests
- add FVector arithmetic and vector math tests

## Testing
- `pnpm build` *(fails: request to registry.npmjs.org blocked)*
- `dotnet run --project GameServer.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9439f7d88333934c8645a4651236