### PR TITLE
Reduce allocations in UDPServer

### DIFF
--- a/Core/Network/UDPServer.cs
+++ b/Core/Network/UDPServer.cs
@@ -298,6 +298,7 @@ public sealed class UDPServer
 
         SendThread = new Thread(() =>
         {
+            var batch = new List<SendPacket>();
             while (Running)
             {
                 SendEvent.WaitOne(1);
@@ -309,7 +310,6 @@ public sealed class UDPServer
                     node = GlobalSendQueue.Clear();
                 }
 
-                var batch = new List<SendPacket>();
                 var chain = node;
 
                 while (node != null)
@@ -652,7 +652,7 @@ public sealed class UDPServer
 
         if (length > 0 && socket != null)
         {
-            byte[] managedBuffer = new byte[length];
+            byte[] managedBuffer = ArrayPool<byte>.Shared.Rent(length);
 
             fixed (byte* dst = managedBuffer)
             {
@@ -664,7 +664,7 @@ public sealed class UDPServer
                 Buffer = managedBuffer,
                 Length = length,
                 Address = socket.RemoteEndPoint,
-                Pooled = false
+                Pooled = true
             };
 
             buffer.Free();


### PR DESCRIPTION
## Summary
- reuse the send batch list in UDP server send thread
- pool buffers when converting `FlatBuffer` to managed arrays

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4e97d488333b6c23c3ab7bb7b35