### PR TITLE
Implement quantization utilities

### DIFF
--- a/Core/Network/FlatBuffer.cs
+++ b/Core/Network/FlatBuffer.cs
@@ -182,6 +182,48 @@ public unsafe struct FlatBuffer : IDisposable
         return val;
     }
 
+    public void WriteQuantized(float value, float min, float max)
+    {
+        short quantized = Quantization.ToShort(value, min, max);
+        Write(quantized);
+    }
+
+    public float ReadQuantizedFloat(float min, float max)
+    {
+        short quantized = ReadShort();
+        return Quantization.ToFloat(quantized, min, max);
+    }
+
+    public void WriteQuantized(FVector value, float min, float max)
+    {
+        WriteQuantized(value.X, min, max);
+        WriteQuantized(value.Y, min, max);
+        WriteQuantized(value.Z, min, max);
+    }
+
+    public FVector ReadQuantizedFVector(float min, float max)
+    {
+        float x = ReadQuantizedFloat(min, max);
+        float y = ReadQuantizedFloat(min, max);
+        float z = ReadQuantizedFloat(min, max);
+        return new FVector(x, y, z);
+    }
+
+    public void WriteQuantized(FRotator value, float min, float max)
+    {
+        WriteQuantized(value.Pitch, min, max);
+        WriteQuantized(value.Yaw, min, max);
+        WriteQuantized(value.Roll, min, max);
+    }
+
+    public FRotator ReadQuantizedFRotator(float min, float max)
+    {
+        float pitch = ReadQuantizedFloat(min, max);
+        float yaw = ReadQuantizedFloat(min, max);
+        float roll = ReadQuantizedFloat(min, max);
+        return new FRotator(pitch, yaw, roll);
+    }
+
     public void Write(FVector value)
     {
         Write((int)value.X);

--- a/Core/Utils/Quantization.cs
+++ b/Core/Utils/Quantization.cs
@@ -1,0 +1,29 @@
+using System;
+
+public static class Quantization
+{
+    public static short ToShort(float value, float min, float max)
+    {
+        float clamped = Math.Clamp(value, min, max);
+        float normalized = (clamped - min) / (max - min);
+        return (short)MathF.Round(normalized * short.MaxValue);
+    }
+
+    public static float ToFloat(short value, float min, float max)
+    {
+        float normalized = value / (float)short.MaxValue;
+        return normalized * (max - min) + min;
+    }
+
+    public static void ToShort(FVector value, float min, float max, out short x, out short y, out short z)
+    {
+        x = ToShort(value.X, min, max);
+        y = ToShort(value.Y, min, max);
+        z = ToShort(value.Z, min, max);
+    }
+
+    public static FVector ToVector(short x, short y, short z, float min, float max)
+    {
+        return new FVector(ToFloat(x, min, max), ToFloat(y, min, max), ToFloat(z, min, max));
+    }
+}

--- a/Tests/Utils/Quantization.test.cs
+++ b/Tests/Utils/Quantization.test.cs
@@ -1,0 +1,37 @@
+namespace Tests
+{
+    public class QuantizationTests : AbstractTest
+    {
+        public QuantizationTests()
+        {
+            Describe("Quantization", () =>
+            {
+                It("should compress and decompress float values", () =>
+                {
+                    float min = -100f;
+                    float max = 100f;
+                    float original = 12.34f;
+
+                    short q = Quantization.ToShort(original, min, max);
+                    float result = Quantization.ToFloat(q, min, max);
+
+                    Expect(result).ToBeApproximately(original, 0.01f);
+                });
+
+                It("should compress and decompress vector values", () =>
+                {
+                    float min = -50f;
+                    float max = 50f;
+                    var vec = new FVector(10.5f, -20.25f, 3.75f);
+
+                    Quantization.ToShort(vec, min, max, out short qx, out short qy, out short qz);
+                    var result = Quantization.ToVector(qx, qy, qz, min, max);
+
+                    Expect(result.X).ToBeApproximately(vec.X, 0.01f);
+                    Expect(result.Y).ToBeApproximately(vec.Y, 0.01f);
+                    Expect(result.Z).ToBeApproximately(vec.Z, 0.01f);
+                });
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new Quantization utility for converting floats and vectors into quantized shorts
- extend `FlatBuffer` with helper methods for reading/writing quantized values
- add unit tests for new quantization features

## Testing
- `pnpm build` *(fails: Request was cancelled - no internet)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719f430e948333bbe2f7d80c201722