### PR TITLE
Add FlatBuffer features

### DIFF
--- a/Core/Network/UDPServer.cs
+++ b/Core/Network/UDPServer.cs
@@ -52,7 +52,7 @@ public class UDPServerOptions
     public int ReceiveBufferSize { get; set; } = 512 * 1024;
     public int SendBufferSize { get; set; } = 512 * 1024;
     public int SendThreadCount { get; set; } = 1;
-    public int MTU = 3600;
+    public int MTU = 1500;
 }
 
 public sealed class UDPServer
@@ -113,7 +113,7 @@ public sealed class UDPServer
     {
         get
         {
-            return _options?.MTU ?? 1472;
+            return _options?.MTU ?? 1500;
         }
     }
 

--- a/Unreal/Source/ToS_Network/Public/Network/UByteBuffer.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UByteBuffer.h
@@ -34,7 +34,7 @@ class TOS_NETWORK_API UByteBuffer : public UObject
 	
 public:
 	UFUNCTION(BlueprintPure, Category = "ByteBuffer")
-	static UByteBuffer* CreateEmptyByteBuffer(int32 Capacity = 3600);
+        static UByteBuffer* CreateEmptyByteBuffer(int32 Capacity = 1500);
 
 	UFUNCTION(BlueprintPure, Category = "ByteBuffer")
 	static UByteBuffer* CreateByteBuffer(const TArray<uint8>& Data);


### PR DESCRIPTION
## Summary
- support bit-level bools and ASCII/UTF8 strings in `FlatBuffer`
- expose peek functionality
- change MTU defaults to 1500 bytes
- update Unreal plugin to match

## Testing
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `dotnet run --project GameServer.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68730e0914988333908685277560bbbe