### PR TITLE
Quantize FVector and FRotator

### DIFF
--- a/Core/Network/FlatBuffer.cs
+++ b/Core/Network/FlatBuffer.cs
@@ -361,34 +361,38 @@ public unsafe struct FlatBuffer : IDisposable
 
     public void Write(FVector value)
     {
-        Write((int)value.X);
-        Write((int)value.Y);
-        Write((int)value.Z);
+        const float factor = 0.1f;
+        Write((short)MathF.Round(value.X / factor));
+        Write((short)MathF.Round(value.Y / factor));
+        Write((short)MathF.Round(value.Z / factor));
     }
 
     public void Write(FRotator value)
     {
-        Write((int)value.Pitch);
-        Write((int)value.Yaw);
-        Write((int)value.Roll);
+        const float factor = 0.1f;
+        Write((short)MathF.Round(value.Pitch / factor));
+        Write((short)MathF.Round(value.Yaw / factor));
+        Write((short)MathF.Round(value.Roll / factor));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public FVector ReadFVector()
     {
-        int x = ReadInt();
-        int y = ReadInt();
-        int z = ReadInt();
-        return new FVector(x, y, z);
+        const float factor = 0.1f;
+        short x = ReadShort();
+        short y = ReadShort();
+        short z = ReadShort();
+        return new FVector(x * factor, y * factor, z * factor);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public FRotator ReadFRotator()
     {
-        int pitch = ReadInt();
-        int yaw = ReadInt();
-        int roll = ReadInt();
-        return new FRotator(pitch, yaw, roll);
+        const float factor = 0.1f;
+        short pitch = ReadShort();
+        short yaw = ReadShort();
+        short roll = ReadShort();
+        return new FRotator(pitch * factor, yaw * factor, roll * factor);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Tests/Network/FlatBuffer.test.cs
+++ b/Tests/Network/FlatBuffer.test.cs
@@ -344,13 +344,13 @@ namespace Tests
                     var originalVector = new FVector(100, 200, 300);
                     var originalRotator = new FRotator(45, 90, 135);
 
-                    buffer.Write(originalVector);    // Uses ZigZag encoding for int components
-                    buffer.Write(originalRotator);   // Uses ZigZag encoding for int components
+                    buffer.Write(originalVector);    // Uses default 0.1 quantization
+                    buffer.Write(originalRotator);   // Uses default 0.1 quantization
 
                     buffer.Reset();
 
-                    var resultVector = buffer.ReadFVector();    // Uses ZigZag decoding
-                    var resultRotator = buffer.ReadFRotator();  // Uses ZigZag decoding
+                    var resultVector = buffer.ReadFVector();    // Applies 0.1 factor
+                    var resultRotator = buffer.ReadFRotator();  // Applies 0.1 factor
 
                     Expect(resultVector.X).ToBe(originalVector.X);
                     Expect(resultVector.Y).ToBe(originalVector.Y);
@@ -359,6 +359,30 @@ namespace Tests
                     Expect(resultRotator.Pitch).ToBe(originalRotator.Pitch);
                     Expect(resultRotator.Yaw).ToBe(originalRotator.Yaw);
                     Expect(resultRotator.Roll).ToBe(originalRotator.Roll);
+                });
+
+                It("should quantize FVector and FRotator by default", () =>
+                {
+                    using var buffer = new FlatBuffer(1024);
+
+                    var originalVector = new FVector(1.23f, -4.56f, 7.89f);
+                    var originalRotator = new FRotator(12.3f, -45.6f, 78.9f);
+
+                    buffer.Write(originalVector);
+                    buffer.Write(originalRotator);
+
+                    buffer.Reset();
+
+                    var resultVector = buffer.ReadFVector();
+                    var resultRotator = buffer.ReadFRotator();
+
+                    Expect(resultVector.X).ToBeApproximately(1.2f, 0.05f);
+                    Expect(resultVector.Y).ToBeApproximately(-4.6f, 0.05f);
+                    Expect(resultVector.Z).ToBeApproximately(7.9f, 0.05f);
+
+                    Expect(resultRotator.Pitch).ToBeApproximately(12.3f, 0.05f);
+                    Expect(resultRotator.Yaw).ToBeApproximately(-45.6f, 0.05f);
+                    Expect(resultRotator.Roll).ToBeApproximately(78.9f, 0.05f);
                 });
             });
 

--- a/Unreal/Source/ToS_Network/Public/Network/UFlatBuffer.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UFlatBuffer.h
@@ -252,35 +252,39 @@ private:
 template<>
 inline void UFlatBuffer::Write<FVector>(const FVector& Value)
 {
-	Write<int32>(static_cast<int32>(Value.X));
-	Write<int32>(static_cast<int32>(Value.Y));
-	Write<int32>(static_cast<int32>(Value.Z));
+        constexpr float Factor = 0.1f;
+        Write<int16>(static_cast<int16>(FMath::RoundToInt(Value.X / Factor)));
+        Write<int16>(static_cast<int16>(FMath::RoundToInt(Value.Y / Factor)));
+        Write<int16>(static_cast<int16>(FMath::RoundToInt(Value.Z / Factor)));
 }
 
 template<>
 inline FVector UFlatBuffer::Read<FVector>()
 {
-	int32 X = Read<int32>();
-	int32 Y = Read<int32>();
-	int32 Z = Read<int32>();
-	return FVector(static_cast<float>(X), static_cast<float>(Y), static_cast<float>(Z));
+        constexpr float Factor = 0.1f;
+        int16 X = Read<int16>();
+        int16 Y = Read<int16>();
+        int16 Z = Read<int16>();
+        return FVector(static_cast<float>(X) * Factor, static_cast<float>(Y) * Factor, static_cast<float>(Z) * Factor);
 }
 
 template<>
 inline void UFlatBuffer::Write<FRotator>(const FRotator& Value)
 {
-        Write<int32>(static_cast<int32>(Value.Pitch));
-        Write<int32>(static_cast<int32>(Value.Yaw));
-        Write<int32>(static_cast<int32>(Value.Roll));
+        constexpr float Factor = 0.1f;
+        Write<int16>(static_cast<int16>(FMath::RoundToInt(Value.Pitch / Factor)));
+        Write<int16>(static_cast<int16>(FMath::RoundToInt(Value.Yaw / Factor)));
+        Write<int16>(static_cast<int16>(FMath::RoundToInt(Value.Roll / Factor)));
 }
 
 template<>
 inline FRotator UFlatBuffer::Read<FRotator>()
 {
-        int32 Pitch = Read<int32>();
-        int32 Yaw = Read<int32>();
-        int32 Roll = Read<int32>();
-        return FRotator(static_cast<float>(Pitch), static_cast<float>(Yaw), static_cast<float>(Roll));
+        constexpr float Factor = 0.1f;
+        int16 Pitch = Read<int16>();
+        int16 Yaw = Read<int16>();
+        int16 Roll = Read<int16>();
+        return FRotator(static_cast<float>(Pitch) * Factor, static_cast<float>(Yaw) * Factor, static_cast<float>(Roll) * Factor);
 }
 
 template<>
@@ -329,4 +333,17 @@ template<>
 inline uint64 UFlatBuffer::Read<uint64>()
 {
         return ReadVarULong();
+}
+
+template<>
+inline void UFlatBuffer::Write<int16>(const int16& Value)
+{
+        Write<uint16>(static_cast<uint16>((Value << 1) ^ (Value >> 15)));
+}
+
+template<>
+inline int16 UFlatBuffer::Read<int16>()
+{
+        uint16 Enc = Read<uint16>();
+        return static_cast<int16>((Enc >> 1) ^ -static_cast<int16>(Enc & 1));
 }


### PR DESCRIPTION
## Summary
- compress FVector and FRotator in FlatBuffer using a fixed 0.1 factor
- add matching logic in Unreal plugin
- update existing unit tests and add coverage for the new quantization

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68731ecf3cb483338943b0ad05db308e