### PR TITLE
Switch UDP networking to FlatBuffer

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Network/ENetSubsystem.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/ENetSubsystem.cpp
@@ -1,6 +1,6 @@
 #include "Network/ENetSubsystem.h"
 #include "Network/UDPClient.h"
-#include "Network/UByteBuffer.h"
+#include "Network/UFlatBuffer.h"
 #include "Misc/ScopeLock.h"
 #include "Sockets.h"
 #include "SocketSubsystem.h"
@@ -11,7 +11,7 @@ void UENetSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
     UdpClient = MakeUnique<UDPClient>();
 
-    UdpClient->OnDataReceive = [this](UByteBuffer* Buffer)
+    UdpClient->OnDataReceive = [this](UFlatBuffer* Buffer)
     {
         if (Buffer)
         {

--- a/Unreal/Source/ToS_Network/Private/Network/UFlatBuffer.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/UFlatBuffer.cpp
@@ -244,6 +244,18 @@ void UFlatBuffer::WriteAsciiString(const FString& Value)
     }
 }
 
+void UFlatBuffer::WriteBytes(const uint8* Source, int32 Length)
+{
+    if (!Source || Length <= 0)
+        return;
+
+    if (Position + Length > Capacity)
+        return;
+
+    FMemory::Memcpy(Data + Position, Source, Length);
+    Position += Length;
+}
+
 void UFlatBuffer::WriteUtf8String(const FString& Value)
 {
     WriteString(Value);

--- a/Unreal/Source/ToS_Network/Public/Network/ENetSubsystem.h
+++ b/Unreal/Source/ToS_Network/Public/Network/ENetSubsystem.h
@@ -25,6 +25,7 @@
 
 #include "CoreMinimal.h"
 #include "Network/UDPClient.h"
+#include "Network/UFlatBuffer.h"
 #include "UObject/Object.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "Containers/Ticker.h"
@@ -45,7 +46,7 @@ public:
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnDisconnected);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnUDPConnectionError);
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnDataReceived, UByteBuffer*, Buffer);
+        DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnDataReceived, UFlatBuffer*, Buffer);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnConnect, const int32&, ClientID);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnConnectDenied);
 

--- a/Unreal/Source/ToS_Network/Public/Network/UDPClient.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UDPClient.h
@@ -33,7 +33,7 @@
 #include "HAL/RunnableThread.h"
 #include "HAL/ThreadSafeBool.h"
 
-class UByteBuffer;
+class UFlatBuffer;
 class UDPClient;
 
 UENUM(BlueprintType)
@@ -80,7 +80,7 @@ public:
     UDPClient();
     ~UDPClient();
 
-    std::function<void(UByteBuffer*)> OnDataReceive;
+    std::function<void(UFlatBuffer*)> OnDataReceive;
     std::function<void(int32)> OnConnect;
     std::function<void()> OnConnectDenied;
     std::function<void()> OnConnectionError;

--- a/Unreal/Source/ToS_Network/Public/Network/UFlatBuffer.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UFlatBuffer.h
@@ -197,7 +197,13 @@ public:
 
 	// Direct memory access methods
 	void CopyFromMemory(const uint8* SourceData, int32 Length);
-	void CopyToMemory(uint8* DestData, int32 Length) const;
+        void CopyToMemory(uint8* DestData, int32 Length) const;
+
+        // Additional helpers to match C# implementation
+        FORCEINLINE int32 SavePosition() const { return Position; }
+        FORCEINLINE void RestorePosition(int32 NewPos) { SetPosition(NewPos); }
+        FORCEINLINE int32 GetLengthBits() const { return (Position * 8) + WriteBitIndex; }
+        void WriteBytes(const uint8* Source, int32 Length);
 
 	// Accessors
 	FORCEINLINE uint8* GetData() { return Data; }


### PR DESCRIPTION
## Summary
- use `UFlatBuffer` instead of removed `UByteBuffer` in Unreal networking code
- update delegates and headers to work with `UFlatBuffer`
- add missing helpers to `UFlatBuffer` to match the C# implementation

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687422fc82d88333952bcfd1f68f80f8