### PR TITLE
Fix template specialization compile issues

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Network/UDPClient.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/UDPClient.cpp
@@ -235,14 +235,14 @@ void UDPClient::PollIncomingPackets()
                     case EPacketType::CheckIntegrity:
                     {
                         uint16 Index = Buffer->ReadUInt16();
-                        uint16 IntegityKey = IntegrityTableData::GetKey(Index);
+                        uint16 IntegrityKey = IntegrityTableData::GetKey(Index);
 
-                        UFlatBuffer* Buffer = UFlatBuffer::CreateFlatBuffer(3);
-                        Buffer->WriteByte(static_cast<uint8>(EPacketType::CheckIntegrity));
-                        Buffer->WriteUInt16(Code);
+                        UFlatBuffer* ResponseBuffer = UFlatBuffer::CreateFlatBuffer(3);
+                        ResponseBuffer->WriteByte(static_cast<uint8>(EPacketType::CheckIntegrity));
+                        ResponseBuffer->WriteUInt16(IntegrityKey);
                         int32 BytesSent = 0;
-                        Socket->SendTo(Buffer->GetRawBuffer(), Buffer->GetLength(), BytesSent, *RemoteEndpoint);
-					}
+                        Socket->SendTo(ResponseBuffer->GetRawBuffer(), ResponseBuffer->GetLength(), BytesSent, *RemoteEndpoint);
+                    }
                     break;
                     default:
                         

--- a/Unreal/Source/ToS_Network/Private/Network/UFlatBuffer.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/UFlatBuffer.cpp
@@ -458,7 +458,7 @@ FString UFlatBuffer::ReadString()
     TArray<UTF8CHAR> TempBuffer;
     TempBuffer.SetNumUninitialized(StringLength + 1);
     FMemory::Memcpy(TempBuffer.GetData(), Data + Position, StringLength);
-    TempBuffer[StringLength] = '\0';
+    TempBuffer[StringLength] = 0;
     Position += StringLength;
 
     return FString(UTF8_TO_TCHAR(TempBuffer.GetData()));
@@ -482,7 +482,7 @@ FString UFlatBuffer::ReadAsciiString()
     TArray<ANSICHAR> Temp;
     Temp.SetNumUninitialized(StringLength + 1);
     FMemory::Memcpy(Temp.GetData(), Data + Position, StringLength);
-    Temp[StringLength] = '\0';
+    Temp[StringLength] = 0;
     Position += StringLength;
 
     return FString(ANSI_TO_TCHAR(Temp.GetData()));


### PR DESCRIPTION
## Summary
- handle CheckIntegrity response correctly in UDP client
- fix UTF-8 buffer termination

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687452cbccc08333ae313450d6a59e74