### PR TITLE
Implement entity handling in UTOSGameInstance

### DIFF
--- a/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
+++ b/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
@@ -1,10 +1,19 @@
 #include "Tos_GameInstance.h"
+#include "Entities/SyncEntity.h"
+#include "Engine/World.h"
 
 static bool bENetInitialized = false;
 
 void UTOSGameInstance::Init()
 {
     Super::Init();
+
+    if (UENetSubsystem* Socket = GetSubsystem<UENetSubsystem>())
+    {
+        Socket->OnCreateEntity.AddDynamic(this, &UTOSGameInstance::HandleCreateEntity);
+        Socket->OnUpdateEntity.AddDynamic(this, &UTOSGameInstance::HandleUpdateEntity);
+        Socket->OnRemoveEntity.AddDynamic(this, &UTOSGameInstance::HandleRemoveEntity);
+    }
 }
 
 void UTOSGameInstance::Shutdown()
@@ -15,8 +24,13 @@ void UTOSGameInstance::Shutdown()
 
     if (UENetSubsystem* Socket = GetSubsystem<UENetSubsystem>())
     {
+        Socket->OnCreateEntity.RemoveDynamic(this, &UTOSGameInstance::HandleCreateEntity);
+        Socket->OnUpdateEntity.RemoveDynamic(this, &UTOSGameInstance::HandleUpdateEntity);
+        Socket->OnRemoveEntity.RemoveDynamic(this, &UTOSGameInstance::HandleRemoveEntity);
         Socket->Disconnect();
     }
+
+    SpawnedEntities.Empty();
 }
 
 void UTOSGameInstance::OnStart()
@@ -32,7 +46,57 @@ void UTOSGameInstance::OnStart()
         
         bENetInitialized = true;
 
-        if (!Socket->IsConnected() && Socket->GetConnectionStatus() != EConnectionStatus::Connecting && ServerAutoConnect) 
+        if (!Socket->IsConnected() && Socket->GetConnectionStatus() != EConnectionStatus::Connecting && ServerAutoConnect)
             Socket->Connect(ServerIP, ServerPort);
-    }    
+    }
+}
+
+ASyncEntity* UTOSGameInstance::GetEntityById(int32 Id) const
+{
+    if (const ASyncEntity* const* Found = SpawnedEntities.Find(Id))
+    {
+        return *Found;
+    }
+    return nullptr;
+}
+
+void UTOSGameInstance::HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags)
+{
+    if (!EntityClass) return;
+
+    UWorld* World = GetWorld();
+    if (!World) return;
+
+    FActorSpawnParameters Params;
+    Params.Owner = nullptr;
+    Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    ASyncEntity* NewEntity = World->SpawnActor<ASyncEntity>(EntityClass, Positon, Rotator, Params);
+    if (NewEntity)
+    {
+        NewEntity->EntityId = EntityId;
+        SpawnedEntities.Add(EntityId, NewEntity);
+    }
+}
+
+void UTOSGameInstance::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags)
+{
+    if (ASyncEntity** Found = SpawnedEntities.Find(EntityId))
+    {
+        ASyncEntity* Entity = *Found;
+        Entity->SetActorLocation(Positon);
+        Entity->SetActorRotation(Rotator);
+    }
+}
+
+void UTOSGameInstance::HandleRemoveEntity(int32 EntityId)
+{
+    if (ASyncEntity* const* Found = SpawnedEntities.Find(EntityId))
+    {
+        ASyncEntity* Entity = *Found;
+        if (Entity && !Entity->IsPendingKill())
+        {
+            Entity->Destroy();
+        }
+        SpawnedEntities.Remove(EntityId);
+    }
 }

--- a/Unreal/Source/ToS_Network/Public/ToS_GameInstance.h
+++ b/Unreal/Source/ToS_Network/Public/ToS_GameInstance.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
 #include "Network/ENetSubsystem.h"
+#include "Entities/SyncEntity.h"
 #include "Tos_GameInstance.generated.h"
 
 UCLASS()
@@ -26,4 +27,23 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Network")
     int32 ServerPort = 3565;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Entities")
+    TSubclassOf<ASyncEntity> EntityClass;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Entities")
+    TMap<int32, ASyncEntity*> SpawnedEntities;
+
+    UFUNCTION(BlueprintCallable, Category = "Entities")
+    ASyncEntity* GetEntityById(int32 Id) const;
+
+private:
+    UFUNCTION()
+    void HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags);
+
+    UFUNCTION()
+    void HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags);
+
+    UFUNCTION()
+    void HandleRemoveEntity(int32 EntityId);
 };


### PR DESCRIPTION
## Summary
- extend `UTOSGameInstance` with entity template and map
- bind server entity events in `UTOSGameInstance`
- add helpers to spawn, update and remove entities on network events

## Testing
- `pnpm build` *(fails: Request to registry.npmjs.org blocked)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875869adb9083339dd87e61c71912f8