### PR TITLE
Improve client animation sync

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Entities/SyncPlayer.cpp
+++ b/Unreal/Source/ToS_Network/Private/Entities/SyncPlayer.cpp
@@ -106,21 +106,17 @@ void ASyncPlayer::SendSyncToServer()
 
     FVector Position = GetActorLocation();
     FRotator Rotation = GetActorRotation();
-    FString AnimName;
+    FString AnimName = TEXT("None");
 
-    if (UAnimInstance* AnimInstance = GetMesh() ? GetMesh()->GetAnimInstance() : nullptr)
+    if (const UAnimInstance* AnimInstance = GetMesh() ? GetMesh()->GetAnimInstance() : nullptr)
     {
-        if (UAnimMontage* Montage = AnimInstance->GetCurrentActiveMontage())        
-            AnimName = Montage->GetName();        
-        else        
-            AnimName = AnimInstance->GetClass()->GetName();
-    }
-    else
-    {
-        AnimName = TEXT("None");
+        if (const UAnimMontage* Montage = AnimInstance->GetCurrentActiveMontage())
+        {
+            AnimName = Montage->GetName();
+        }
     }
 
-    int32 AnimID = UBase36::Base36ToInt(AnimName);
+    const int32 AnimID = AnimName == TEXT("None") ? 0 : UBase36::Base36ToInt(AnimName);
 
     struct FSyncSnapshot
     {

--- a/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
+++ b/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
@@ -85,8 +85,21 @@ void UTOSGameInstance::HandleUpdateEntity(int32 EntityId, FVector Positon, FRota
     if (ASyncEntity** Found = SpawnedEntities.Find(EntityId))
     {
         ASyncEntity* Entity = *Found;
-        Entity->SetActorLocation(Positon);
-        Entity->SetActorRotation(Rotator);
+        if (UWorld* World = GetWorld())
+        {
+            float Delta = World->GetDeltaSeconds();
+            FVector NewLocation = FMath::VInterpTo(Entity->GetActorLocation(), Positon, Delta, 10.f);
+            FRotator NewRotation = FMath::RInterpTo(Entity->GetActorRotation(), Rotator, Delta, 10.f);
+            Entity->SetActorLocation(NewLocation);
+            Entity->SetActorRotation(NewRotation);
+        }
+        else
+        {
+            Entity->SetActorLocation(Positon);
+            Entity->SetActorRotation(Rotator);
+        }
+
+        Entity->AnimationState = AnimationState;
     }
 }
 

--- a/Unreal/Source/ToS_Network/Public/Entities/SyncEntity.h
+++ b/Unreal/Source/ToS_Network/Public/Entities/SyncEntity.h
@@ -12,10 +12,13 @@ class TOS_NETWORK_API ASyncEntity : public ACharacter
 	GENERATED_BODY()
 
 public:
-	ASyncEntity();
+        ASyncEntity();
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Entity)
-	int32 EntityId;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Entity)
+        int32 EntityId;
+
+        UPROPERTY(BlueprintReadWrite, Category = Entity)
+        int32 AnimationState = 0;
 
 protected:
 	virtual void BeginPlay() override;


### PR DESCRIPTION
## Summary
- determine montage name only if a montage is playing
- store animation state on `ASyncEntity`
- interpolate remote entity transforms when updating

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68770bea5df08333b372ff147fe91616