### PR TITLE
Handle missing entities on update

### DIFF
--- a/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
+++ b/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
@@ -101,6 +101,24 @@ void UTOSGameInstance::HandleUpdateEntity(int32 EntityId, FVector Positon, FRota
 
         Entity->AnimationState = AnimationState;
     }
+    else if (EntityClass)
+    {
+        UWorld* World = GetWorld();
+        if (!World)
+            return;
+
+        FActorSpawnParameters Params;
+        Params.Owner = nullptr;
+        Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+        ASyncEntity* NewEntity = World->SpawnActor<ASyncEntity>(EntityClass, Positon, Rotator, Params);
+
+        if (NewEntity)
+        {
+            NewEntity->EntityId = EntityId;
+            NewEntity->AnimationState = AnimationState;
+            SpawnedEntities.Add(EntityId, NewEntity);
+        }
+    }
 }
 
 void UTOSGameInstance::HandleRemoveEntity(int32 EntityId)


### PR DESCRIPTION
## Summary
- spawn an entity when `HandleUpdateEntity` receives an unknown ID

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687712b49a54833390dfec8ac071334b