### PR TITLE
Move entity spawning to GameMode

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Tos_GameMode.cpp
+++ b/Unreal/Source/ToS_Network/Private/Tos_GameMode.cpp
@@ -1,0 +1,86 @@
+#include "Tos_GameMode.h"
+#include "Engine/World.h"
+
+ASyncEntity* ATOSGameMode::GetEntityById(int32 Id)
+{
+    if (ASyncEntity** Found = SpawnedEntities.Find(Id))
+    {
+        return *Found;
+    }
+
+    return nullptr;
+}
+
+void ATOSGameMode::HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags)
+{
+    if (!EntityClass) return;
+
+    UWorld* World = GetWorld();
+    if (!World) return;
+
+    FActorSpawnParameters Params;
+    Params.Owner = nullptr;
+    Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    ASyncEntity* NewEntity = World->SpawnActor<ASyncEntity>(EntityClass, Positon, Rotator, Params);
+
+    if (NewEntity)
+    {
+        NewEntity->EntityId = EntityId;
+        SpawnedEntities.Add(EntityId, NewEntity);
+    }
+}
+
+void ATOSGameMode::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags)
+{
+    if (ASyncEntity** Found = SpawnedEntities.Find(EntityId))
+    {
+        ASyncEntity* Entity = *Found;
+        if (UWorld* World = GetWorld())
+        {
+            float Delta = World->GetDeltaSeconds();
+            FVector NewLocation = FMath::VInterpTo(Entity->GetActorLocation(), Positon, Delta, 10.f);
+            FRotator NewRotation = FMath::RInterpTo(Entity->GetActorRotation(), Rotator, Delta, 10.f);
+            Entity->SetActorLocation(NewLocation);
+            Entity->SetActorRotation(NewRotation);
+        }
+        else
+        {
+            Entity->SetActorLocation(Positon);
+            Entity->SetActorRotation(Rotator);
+        }
+
+        Entity->AnimationState = AnimationState;
+    }
+    else if (EntityClass)
+    {
+        UWorld* World = GetWorld();
+        if (!World)
+            return;
+
+        FActorSpawnParameters Params;
+        Params.Owner = nullptr;
+        Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+        ASyncEntity* NewEntity = World->SpawnActor<ASyncEntity>(EntityClass, Positon, Rotator, Params);
+
+        if (NewEntity)
+        {
+            NewEntity->EntityId = EntityId;
+            NewEntity->AnimationState = AnimationState;
+            SpawnedEntities.Add(EntityId, NewEntity);
+        }
+    }
+}
+
+void ATOSGameMode::HandleRemoveEntity(int32 EntityId)
+{
+    if (ASyncEntity* const* Found = SpawnedEntities.Find(EntityId))
+    {
+        ASyncEntity* Entity = *Found;
+
+        if (Entity)
+            Entity->Destroy();
+
+        SpawnedEntities.Remove(EntityId);
+    }
+}
+

--- a/Unreal/Source/ToS_Network/Public/ToS_GameInstance.h
+++ b/Unreal/Source/ToS_Network/Public/ToS_GameInstance.h
@@ -3,14 +3,14 @@
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
 #include "Network/ENetSubsystem.h"
-#include "Entities/SyncEntity.h"
-#include "Entities/SyncPlayer.h"
 #include "Tos_GameInstance.generated.h"
+
+class ATOSGameMode;
 
 UCLASS()
 class TOS_NETWORK_API UTOSGameInstance : public UGameInstance
 {
-	GENERATED_BODY()
+    GENERATED_BODY()
 
 public:
     virtual void Init() override;
@@ -29,18 +29,6 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Network")
     int32 ServerPort = 3565;
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Entities")
-    TSubclassOf<ASyncEntity> EntityClass;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Entities")
-    TSubclassOf<ASyncPlayer> PlayerClass;
-
-    UPROPERTY(BlueprintReadOnly, Category = "Entities")
-    TMap<int32, ASyncEntity*> SpawnedEntities;
-
-    UFUNCTION(BlueprintCallable, Category = "Entities")
-    ASyncEntity* GetEntityById(int32 Id);
-
 private:
     UFUNCTION()
     void HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags);
@@ -51,3 +39,4 @@ private:
     UFUNCTION()
     void HandleRemoveEntity(int32 EntityId);
 };
+

--- a/Unreal/Source/ToS_Network/Public/Tos_GameMode.h
+++ b/Unreal/Source/ToS_Network/Public/Tos_GameMode.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "Entities/SyncEntity.h"
+#include "Entities/SyncPlayer.h"
+#include "Tos_GameMode.generated.h"
+
+UCLASS()
+class TOS_NETWORK_API ATOSGameMode : public AGameModeBase
+{
+    GENERATED_BODY()
+
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Entities")
+    TSubclassOf<ASyncEntity> EntityClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Entities")
+    TSubclassOf<ASyncPlayer> PlayerClass;
+
+    UPROPERTY(BlueprintReadOnly, Category = "Entities")
+    TMap<int32, ASyncEntity*> SpawnedEntities;
+
+    UFUNCTION(BlueprintCallable, Category = "Entities")
+    ASyncEntity* GetEntityById(int32 Id);
+
+    UFUNCTION()
+    void HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags);
+
+    UFUNCTION()
+    void HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags);
+
+    UFUNCTION()
+    void HandleRemoveEntity(int32 EntityId);
+};
+


### PR DESCRIPTION
## Summary
- add new `ATOSGameMode` class that manages entity spawning
- adjust `UTOSGameInstance` to forward network events to the game mode
- remove entity spawn logic from `UTOSGameInstance`

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772ae448e483339afe154b7f67a819