### PR TITLE
Add PlayerController ready callback

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Controllers/Tos_PlayerController.cpp
+++ b/Unreal/Source/ToS_Network/Private/Controllers/Tos_PlayerController.cpp
@@ -1,5 +1,16 @@
 #include "Controllers/ToS_PlayerController.h"
+#include "Tos_GameInstance.h"
 #include "Engine/World.h"
+
+void ATOSPlayerController::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (UTOSGameInstance* GI = GetGameInstance<UTOSGameInstance>())
+    {
+        GI->OnPlayerControllerReady(this);
+    }
+}
 
 ASyncEntity* ATOSPlayerController::GetEntityById(int32 Id)
 {

--- a/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
+++ b/Unreal/Source/ToS_Network/Private/ToS_GameInstance.cpp
@@ -4,6 +4,11 @@
 
 static bool bENetInitialized = false;
 
+void UTOSGameInstance::OnPlayerControllerReady(ATOSPlayerController* Controller)
+{
+    PlayerController = Controller;
+}
+
 void UTOSGameInstance::Init()
 {
     Super::Init();
@@ -51,34 +56,25 @@ void UTOSGameInstance::OnStart()
 
 void UTOSGameInstance::HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags)
 {
-    if (UWorld* World = GetWorld())
+    if (PlayerController)
     {
-        if (ATOSPlayerController* PlayerController = Cast<ATOSPlayerController>(World->GetFirstPlayerController()))
-        {
-            PlayerController->HandleCreateEntity(EntityId, Positon, Rotator, Flags);
-        }
+        PlayerController->HandleCreateEntity(EntityId, Positon, Rotator, Flags);
     }
 }
 
 void UTOSGameInstance::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags)
 {
-    if (UWorld* World = GetWorld())
+    if (PlayerController)
     {
-        if (ATOSPlayerController* PlayerController = Cast<ATOSPlayerController>(World->GetFirstPlayerController()))
-        {
-            PlayerController->HandleUpdateEntity(EntityId, Positon, Rotator, AnimationState, Flags);
-        }
+        PlayerController->HandleUpdateEntity(EntityId, Positon, Rotator, AnimationState, Flags);
     }
 }
 
 void UTOSGameInstance::HandleRemoveEntity(int32 EntityId)
 {
-    if (UWorld* World = GetWorld())
+    if (PlayerController)
     {
-        if (ATOSPlayerController* PlayerController = Cast<ATOSPlayerController>(World->GetFirstPlayerController()))
-        {
-            PlayerController->HandleRemoveEntity(EntityId);
-        }
+        PlayerController->HandleRemoveEntity(EntityId);
     }
 }
 

--- a/Unreal/Source/ToS_Network/Public/Controllers/Tos_PlayerController.h
+++ b/Unreal/Source/ToS_Network/Public/Controllers/Tos_PlayerController.h
@@ -32,5 +32,8 @@ public:
 
     UFUNCTION()
     void HandleRemoveEntity(int32 EntityId);
+
+protected:
+    virtual void BeginPlay() override;
 };
 

--- a/Unreal/Source/ToS_Network/Public/ToS_GameInstance.h
+++ b/Unreal/Source/ToS_Network/Public/ToS_GameInstance.h
@@ -17,6 +17,8 @@ public:
     virtual void OnStart() override;
     virtual void Shutdown() override;
 
+    void OnPlayerControllerReady(ATOSPlayerController* Controller);
+
     UFUNCTION(BlueprintImplementableEvent, Category = "GameInstance")
     void OnGameInstanceStarted();
 
@@ -30,6 +32,9 @@ public:
     int32 ServerPort = 3565;
 
 private:
+    UPROPERTY()
+    ATOSPlayerController* PlayerController = nullptr;
+
     UFUNCTION()
     void HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags);
 


### PR DESCRIPTION
## Summary
- allow `UTOSGameInstance` to store player controller reference
- trigger `OnPlayerControllerReady` from `ATOSPlayerController::BeginPlay`
- adjust entity handling functions to use stored controller

## Testing
- `pnpm build` *(fails: unable to fetch pnpm)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68773d82126483339d61fe3b9b055d57