### PR TITLE
Cleanup entities on disconnect and sync speed

### DIFF
--- a/Contract/EntityContracts.cs
+++ b/Contract/EntityContracts.cs
@@ -23,6 +23,9 @@ public partial struct SyncEntityPacket
     [ContractField("FRotator")]
     public FRotator Rotator;
 
+    [ContractField("float")]
+    public float Speed;
+
     [ContractField("ushort")]
     public ushort AnimationState;
 }

--- a/Core/Entities/Entity.cs
+++ b/Core/Entities/Entity.cs
@@ -43,6 +43,7 @@ public partial struct Entity
     public FVector Position;
     public FRotator Rotation;
     public uint AnimState;
+    public float Speed;
 
     //AIO Control
     public uint WorldId;
@@ -262,6 +263,26 @@ public static class EntityManager
             throw new KeyNotFoundException($"Entity with ID {id} not found");
 
         return ref entityRef;
+    }
+
+    public static void CleanupSocket(UDPSocket socket)
+    {
+        if (socket == null)
+            return;
+
+        List<uint> removeIds = new();
+
+        foreach (var pair in _entities)
+        {
+            if (pair.Value.Socket == socket)
+                removeIds.Add(pair.Key);
+        }
+
+        foreach (var id in removeIds)
+        {
+            Remove(id);
+            EntitySocketMap.Unbind(id);
+        }
     }
 }
 

--- a/Core/Handlers/SyncEntity.cs
+++ b/Core/Handlers/SyncEntity.cs
@@ -10,6 +10,8 @@ namespace Packets.Handler
             SyncEntityPacket syncEntityPacket = new SyncEntityPacket();
             syncEntityPacket.Deserialize(ref buffer);
 
+            var delta = syncEntityPacket.Positon - ctrl.Entity.Position;
+            ctrl.Entity.Speed = delta.Size() / 0.05f;
             ctrl.Entity.Move(syncEntityPacket.Positon);
             ctrl.Entity.Rotate(syncEntityPacket.Rotator);
             ctrl.Entity.SetAnimState(syncEntityPacket.AnimationState);

--- a/Core/Network/UDPSocket.cs
+++ b/Core/Network/UDPSocket.cs
@@ -226,6 +226,8 @@ public class UDPSocket
     {
         if (State != ConnectionState.Disconnected)
             State = ConnectionState.Disconnected;
+
+        EntityManager.CleanupSocket(this);
     }
 
     public bool AddReliablePacket(short packetId, FlatBuffer buffer)

--- a/Core/Packets/UpdateEntityPacket.cs
+++ b/Core/Packets/UpdateEntityPacket.cs
@@ -4,7 +4,14 @@ using System.Runtime.CompilerServices;
 
 public partial struct UpdateEntityPacket: INetworkPacket
 {
-    public int Size => 25;
+    public int Size => 29;
+
+    public uint EntityId;
+    public FVector Positon;
+    public FRotator Rotator;
+    public float Speed;
+    public ushort AnimationState;
+    public uint Flags;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Serialize(ref FlatBuffer buffer)
@@ -14,6 +21,7 @@ public partial struct UpdateEntityPacket: INetworkPacket
         buffer.Write(EntityId);
         buffer.Write(Positon, 0.1f);
         buffer.Write(Rotator, 0.1f);
+        buffer.Write(Speed);
         buffer.Write(AnimationState);
         buffer.Write(Flags);
     }
@@ -24,6 +32,7 @@ public partial struct UpdateEntityPacket: INetworkPacket
         EntityId = buffer.Read<uint>();
         Positon = buffer.ReadFVector(0.1f);
         Rotator = buffer.ReadFRotator(0.1f);
+        Speed = buffer.Read<float>();
         AnimationState = buffer.Read<ushort>();
         Flags = buffer.Read<uint>();
     }

--- a/Core/Player/PlayerController.cs
+++ b/Core/Player/PlayerController.cs
@@ -77,6 +77,7 @@ public partial class PlayerController
             EntityId = entity.Id,
             Positon = entity.Position,
             Rotator = entity.Rotation,
+            Speed = entity.Speed,
             AnimationState = (ushort)entity.AnimState,
             Flags = (uint)entity.Flags
         };

--- a/Unreal/Source/ToS_Network/Private/Controllers/ToS_GameInstance.cpp
+++ b/Unreal/Source/ToS_Network/Private/Controllers/ToS_GameInstance.cpp
@@ -71,16 +71,16 @@ void UTOSGameInstance::HandleCreateEntity(int32 EntityId, FVector Positon, FRota
     });
 }
 
-void UTOSGameInstance::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags)
+void UTOSGameInstance::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, float Speed, int32 AnimationState, int32 Flags)
 {
     if (!PlayerController)
         return;
 
-    AsyncTask(ENamedThreads::GameThread, [this, EntityId, Positon, Rotator, AnimationState, Flags]()
+    AsyncTask(ENamedThreads::GameThread, [this, EntityId, Positon, Rotator, Speed, AnimationState, Flags]()
     {
         if (PlayerController)
         {
-            PlayerController->HandleUpdateEntity(EntityId, Positon, Rotator, AnimationState, Flags);
+            PlayerController->HandleUpdateEntity(EntityId, Positon, Rotator, Speed, AnimationState, Flags);
         }
     });
 }

--- a/Unreal/Source/ToS_Network/Private/Controllers/Tos_PlayerController.cpp
+++ b/Unreal/Source/ToS_Network/Private/Controllers/Tos_PlayerController.cpp
@@ -52,7 +52,7 @@ void ATOSPlayerController::HandleCreateEntity(int32 EntityId, FVector Positon, F
     }
 }
 
-void ATOSPlayerController::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags)
+void ATOSPlayerController::HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, float Speed, int32 AnimationState, int32 Flags)
 {
     if (!bIsReadyToSync) return;
 
@@ -78,6 +78,7 @@ void ATOSPlayerController::HandleUpdateEntity(int32 EntityId, FVector Positon, F
         }
 
         Entity->AnimationState = AnimationState;
+        Entity->UpdateAnimationFromNetwork(Speed, AnimationState);
     }
     else if (EntityClass)
     {
@@ -95,6 +96,7 @@ void ATOSPlayerController::HandleUpdateEntity(int32 EntityId, FVector Positon, F
         {
             NewEntity->EntityId = EntityId;
             NewEntity->AnimationState = AnimationState;
+            NewEntity->UpdateAnimationFromNetwork(Speed, AnimationState);
             SpawnedEntities.Add(EntityId, NewEntity);
         }
     }

--- a/Unreal/Source/ToS_Network/Private/Entities/SyncEntity.cpp
+++ b/Unreal/Source/ToS_Network/Private/Entities/SyncEntity.cpp
@@ -28,8 +28,20 @@ void ASyncEntity::BeginPlay()
 
 void ASyncEntity::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-	if (GetWorld())	
-		GetWorld()->GetTimerManager().ClearTimer(NetSyncTimerHandle);
-	
-	Super::EndPlay(EndPlayReason);
+        if (GetWorld())
+                GetWorld()->GetTimerManager().ClearTimer(NetSyncTimerHandle);
+
+        Super::EndPlay(EndPlayReason);
+}
+
+void ASyncEntity::UpdateAnimationFromNetwork(float Speed, uint32 AnimationState)
+{
+        if (UCharacterMovementComponent* MoveComp = GetCharacterMovement())
+        {
+                FVector Forward = GetActorForwardVector() * Speed;
+                MoveComp->Velocity = Forward;
+        }
+
+        this->AnimationState = static_cast<int32>(AnimationState);
+        SetSpeed(Speed);
 }

--- a/Unreal/Source/ToS_Network/Private/Network/ENetSubsystem.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/ENetSubsystem.cpp
@@ -47,7 +47,7 @@ void UENetSubsystem::Initialize(FSubsystemCollectionBase& Collection)
                 {
                     FUpdateEntityPacket fUpdateEntity = FUpdateEntityPacket();
                     fUpdateEntity.Deserialize(Buffer);
-                    OnUpdateEntity.Broadcast(fUpdateEntity.EntityId, fUpdateEntity.Positon, fUpdateEntity.Rotator, fUpdateEntity.AnimationState, fUpdateEntity.Flags);
+                    OnUpdateEntity.Broadcast(fUpdateEntity.EntityId, fUpdateEntity.Positon, fUpdateEntity.Rotator, fUpdateEntity.Speed, fUpdateEntity.AnimationState, fUpdateEntity.Flags);
                     break;
                 }
                 case EServerPackets::RemoveEntity:

--- a/Unreal/Source/ToS_Network/Public/Controllers/ToS_GameInstance.h
+++ b/Unreal/Source/ToS_Network/Public/Controllers/ToS_GameInstance.h
@@ -47,7 +47,7 @@ private:
     void HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags);
 
     UFUNCTION()
-    void HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags);
+    void HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, float Speed, int32 AnimationState, int32 Flags);
 
     UFUNCTION()
     void HandleRemoveEntity(int32 EntityId);

--- a/Unreal/Source/ToS_Network/Public/Controllers/Tos_PlayerController.h
+++ b/Unreal/Source/ToS_Network/Public/Controllers/Tos_PlayerController.h
@@ -28,7 +28,7 @@ public:
     void HandleCreateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 Flags);
 
     UFUNCTION()
-    void HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, int32 AnimationState, int32 Flags);
+    void HandleUpdateEntity(int32 EntityId, FVector Positon, FRotator Rotator, float Speed, int32 AnimationState, int32 Flags);
 
     UFUNCTION()
     void HandleRemoveEntity(int32 EntityId);

--- a/Unreal/Source/ToS_Network/Public/Entities/SyncEntity.h
+++ b/Unreal/Source/ToS_Network/Public/Entities/SyncEntity.h
@@ -20,6 +20,12 @@ public:
         UPROPERTY(BlueprintReadWrite, Category = Entity)
         int32 AnimationState = 0;
 
+        UFUNCTION(BlueprintCallable, Category = "Network")
+        void UpdateAnimationFromNetwork(float Speed, uint32 AnimationState);
+
+        UFUNCTION(BlueprintImplementableEvent, Category = "Network")
+        void SetSpeed(float Speed);
+
 protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;

--- a/Unreal/Source/ToS_Network/Public/Network/ENetSubsystem.h
+++ b/Unreal/Source/ToS_Network/Public/Network/ENetSubsystem.h
@@ -61,7 +61,7 @@ public:
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnConnectDenied);
     DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FBenchmarkHandler, int32, Id, FVector, Positon, FRotator, Rotator);
     DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(FCreateEntityHandler, int32, EntityId, FVector, Positon, FRotator, Rotator, int32, Flags);
-    DECLARE_DYNAMIC_MULTICAST_DELEGATE_FiveParams(FUpdateEntityHandler, int32, EntityId, FVector, Positon, FRotator, Rotator, int32, AnimationState, int32, Flags);
+    DECLARE_DYNAMIC_MULTICAST_DELEGATE_SixParams(FUpdateEntityHandler, int32, EntityId, FVector, Positon, FRotator, Rotator, float, Speed, int32, AnimationState, int32, Flags);
     DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRemoveEntityHandler, int32, EntityId);
     DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FDeltaSyncHandler, int32, Index, uint8, EntitiesMask);
     DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSyncStateIntHandler);

--- a/Unreal/Source/ToS_Network/Public/Packets/UpdateEntityPacket.h
+++ b/Unreal/Source/ToS_Network/Public/Packets/UpdateEntityPacket.h
@@ -22,19 +22,23 @@ struct FUpdateEntityPacket
     FRotator Rotator;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Speed;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
     int32 AnimationState;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     int32 Flags;
 
 
-    int32 GetSize() const { return 37; }
+    int32 GetSize() const { return 41; }
 
     void Deserialize(UFlatBuffer* Buffer)
     {
         EntityId = static_cast<int32>(Buffer->Read<uint32>());
         Positon = Buffer->Read<FVector>();
         Rotator = Buffer->Read<FRotator>();
+        Speed = Buffer->Read<float>();
         AnimationState = static_cast<int32>(Buffer->Read<uint16>());
         Flags = static_cast<int32>(Buffer->Read<uint32>());
     }


### PR DESCRIPTION
## Summary
- remove entities related to a disconnected socket
- propagate entity speed with `UpdateEntityPacket`
- compute speed on server when processing `SyncEntity`
- update client-side classes to handle network speed
- expose `UpdateAnimationFromNetwork` for animation

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687767171f0483339f83742b349268b2