### PR TITLE
Add LastUpdate tracking for entities

### DIFF
--- a/Core/Entities/Entity.cs
+++ b/Core/Entities/Entity.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -44,6 +45,8 @@ public partial struct Entity
     public FRotator Rotation;
     public FVector Velocity;
     public uint AnimState;
+
+    public DateTime LastUpdate;
     
     //AIO Control
     public uint WorldId;
@@ -54,6 +57,7 @@ public partial struct Entity
     {
         Id = id;
         Type = type;
+        LastUpdate = DateTime.UtcNow;
     }
 
     public World World {
@@ -122,6 +126,7 @@ public partial struct Entity
 
         Snapshot();
         Position = position;
+        LastUpdate = DateTime.UtcNow;
     }
 
     public void Rotate(FRotator rotation)
@@ -131,6 +136,7 @@ public partial struct Entity
 
         Snapshot();
         Rotation = rotation;
+        LastUpdate = DateTime.UtcNow;
     }
 
     public void SetAnimState(uint animState)
@@ -140,6 +146,7 @@ public partial struct Entity
 
         Snapshot();
         AnimState = animState;
+        LastUpdate = DateTime.UtcNow;
     }
 
     public void SetVelocity(FVector velocity)
@@ -149,6 +156,7 @@ public partial struct Entity
 
         Snapshot();
         Velocity = velocity;
+        LastUpdate = DateTime.UtcNow;
     }
 
     public EntityDelta Delta()

--- a/Core/Player/PlayerController.cs
+++ b/Core/Player/PlayerController.cs
@@ -2,6 +2,7 @@
 using NanoSockets;
 using Spectre.Console;
 using System.Collections.Concurrent;
+using System;
 
 public partial class PlayerController
 {
@@ -66,6 +67,12 @@ public partial class PlayerController
     {
         if (!EntityManager.TryGet(EntityId, out var entity))
             return;
+
+        if ((DateTime.UtcNow - entity.LastUpdate).TotalMilliseconds > 300)
+        {
+            entity.Snapshot();
+            entity.Velocity = FVector.Zero;
+        }
 
         var neighbours = EntityManager.GetNearestEntities(EntityId);
 


### PR DESCRIPTION
## Summary
- track the timestamp of the last entity update
- zero velocity if a player hasn't updated in 300ms

## Testing
- `pnpm build` *(fails: unable to fetch pnpm)*
- `dotnet run --project GameServer.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878782138a08333b5a582dbedef92cd