### PR TITLE
Prefix delta packets with size

### DIFF
--- a/Core/Entities/Entity.cs
+++ b/Core/Entities/Entity.cs
@@ -330,11 +330,16 @@ public partial struct DeltaSyncPacket
     {
         var delta = entity.Delta();
 
-        if(delta != EntityDelta.None)
+        if (delta != EntityDelta.None)
         {
             buffer.Write(PacketType.Unreliable);
             buffer.Write((ushort)ServerPackets.DeltaSync);
             buffer.Write(entity.Id);
+
+            int sizePos = buffer.SavePosition();
+            buffer.Write((ushort)0);
+            int start = buffer.Position;
+
             buffer.Write((byte)delta);
 
             if (delta.HasFlag(EntityDelta.Position))
@@ -347,6 +352,12 @@ public partial struct DeltaSyncPacket
                 buffer.Write(entity.Velocity);
             if (delta.HasFlag(EntityDelta.Flags))
                 buffer.Write(entity.Flags);
-        }        
+
+            int end = buffer.Position;
+            ushort size = (ushort)(end - start);
+            buffer.RestorePosition(sizePos);
+            buffer.Write(size);
+            buffer.RestorePosition(end);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- prefix each DeltaSync packet with its own size so clients can parse multiple deltas in a single buffer
- update Unreal plugin to read the new size prefix when processing DeltaSync packets

## Testing
- `pnpm build` *(failed: Error when performing the request to registry.npmjs.org)*
- `dotnet run --project GameServer.csproj` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fcb0387c8333a32ff6b7219b26a8