### PR TITLE
Add smooth interpolation for networked entities

### DIFF
--- a/Unreal/Source/ToS_Network/Private/Controllers/Tos_PlayerController.cpp
+++ b/Unreal/Source/ToS_Network/Private/Controllers/Tos_PlayerController.cpp
@@ -131,10 +131,10 @@ void ATOSPlayerController::HandleDeltaUpdate(FDeltaUpdateData data)
 void ATOSPlayerController::ApplyDeltaData(ASyncEntity* Entity, const FDeltaUpdateData& Data)
 {
     if (EnumHasAnyFlags(Data.EntitiesMask, EEntityDelta::Position))
-        Entity->SetActorLocation(Data.Positon);
+        Entity->TargetLocation = Data.Positon;
 
     if (EnumHasAnyFlags(Data.EntitiesMask, EEntityDelta::Rotation))
-        Entity->SetActorRotation(Data.Rotator);
+        Entity->TargetRotation = Data.Rotator;
 
     if (EnumHasAnyFlags(Data.EntitiesMask, EEntityDelta::AnimState | EEntityDelta::Velocity | EEntityDelta::Flags))
     {

--- a/Unreal/Source/ToS_Network/Private/Entities/SyncEntity.cpp
+++ b/Unreal/Source/ToS_Network/Private/Entities/SyncEntity.cpp
@@ -6,7 +6,7 @@
 
 ASyncEntity::ASyncEntity()
 {
-	PrimaryActorTick.bCanEverTick = true;
+        PrimaryActorTick.bCanEverTick = true;
 
 	bUseControllerRotationPitch = false;
 	bUseControllerRotationYaw = false;
@@ -25,7 +25,10 @@ ASyncEntity::ASyncEntity()
 
 void ASyncEntity::BeginPlay()
 {
-	Super::BeginPlay();
+        Super::BeginPlay();
+
+    TargetLocation = GetActorLocation();
+    TargetRotation = GetActorRotation();
 
 	if (UWorld* World = GetWorld())
 	{
@@ -46,6 +49,19 @@ void ASyncEntity::EndPlay(const EEndPlayReason::Type EndPlayReason)
 		GetWorld()->GetTimerManager().ClearTimer(NetSyncTimerHandle);
 
     Super::EndPlay(EndPlayReason);
+}
+
+void ASyncEntity::Tick(float DeltaTime)
+{
+    Super::Tick(DeltaTime);
+
+    const float InterpSpeed = 10.0f;
+
+    FVector NewLocation = FMath::VInterpTo(GetActorLocation(), TargetLocation, DeltaTime, InterpSpeed);
+    SetActorLocation(NewLocation);
+
+    FRotator NewRotation = FMath::RInterpTo(GetActorRotation(), TargetRotation, DeltaTime, InterpSpeed);
+    SetActorRotation(NewRotation);
 }
 
 void ASyncEntity::UpdateAnimationFromNetwork(FVector Velocity, uint32 Animation, bool IsFalling)

--- a/Unreal/Source/ToS_Network/Public/Entities/SyncEntity.h
+++ b/Unreal/Source/ToS_Network/Public/Entities/SyncEntity.h
@@ -17,6 +17,12 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Entity)
     int32 EntityId;
 
+    UPROPERTY(BlueprintReadWrite, Category = "Network")
+    FVector TargetLocation;
+
+    UPROPERTY(BlueprintReadWrite, Category = "Network")
+    FRotator TargetRotation;
+
     void UpdateAnimationFromNetwork(FVector Velocity, uint32 Animation, bool IsFalling);
 
     UFUNCTION(BlueprintImplementableEvent, Category = "Network")
@@ -25,7 +31,8 @@ public:
 	int32 AnimationState = 0;
 
 protected:
-	virtual void BeginPlay() override;
+    virtual void Tick(float DeltaTime) override;
+    virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 	UPROPERTY()


### PR DESCRIPTION
## Summary
- track target transform in `ASyncEntity`
- smoothly interpolate towards networked position/rotation
- update controller to set interpolation targets

## Testing
- `pnpm build` *(fails: Request was cancelled)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687913180b9083338445d6ded69bccad