### PR TITLE
Add X25519 handshake and ChaCha20-Poly1305 wrappers

### DIFF
--- a/Core/Network/SecureSession.cs
+++ b/Core/Network/SecureSession.cs
@@ -1,0 +1,152 @@
+using System.Buffers.Binary;
+using Org.BouncyCastle.Crypto.Agreement;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Utilities;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Crypto;
+
+public readonly struct Header
+{
+    public readonly uint ConnId;
+    public readonly ulong Seq;
+    public readonly PacketFlags Flags;
+    public readonly byte ChannelId;
+
+    public Header(uint connId, ulong seq, PacketFlags flags, byte channelId)
+    {
+        ConnId = connId;
+        Seq = seq;
+        Flags = flags;
+        ChannelId = channelId;
+    }
+
+    public byte[] ToArray()
+    {
+        Span<byte> buf = stackalloc byte[14];
+        BinaryPrimitives.WriteUInt32BigEndian(buf, ConnId);
+        BinaryPrimitives.WriteUInt64BigEndian(buf.Slice(4), Seq);
+        buf[12] = (byte)Flags;
+        buf[13] = ChannelId;
+        return buf.ToArray();
+    }
+}
+
+public sealed class SecureSession
+{
+    private static readonly byte[] Info = System.Text.Encoding.ASCII.GetBytes("ToS-UE5 v1");
+
+    public readonly byte[] TxKey;
+    public readonly byte[] RxKey;
+    public readonly byte[] DirSalt;
+
+    public ulong SeqTx;
+    public ulong SeqRx;
+
+    private SecureSession(byte[] txKey, byte[] rxKey, byte[] dirSalt)
+    {
+        TxKey = txKey;
+        RxKey = rxKey;
+        DirSalt = dirSalt;
+        SeqTx = 0;
+        SeqRx = 0;
+    }
+
+    public static (byte[] serverPublicKey, byte[] salt, SecureSession session) CreateAsServer(ReadOnlySpan<byte> clientPublicKey)
+    {
+        var rng = new SecureRandom();
+        var serverPriv = new X25519PrivateKeyParameters(rng);
+        var serverPub = serverPriv.GeneratePublicKey().GetEncoded();
+
+        var clientPub = new X25519PublicKeyParameters(clientPublicKey);
+        var agreement = new X25519Agreement();
+        agreement.Init(serverPriv);
+        byte[] sharedSecret = new byte[agreement.AgreementSize];
+        agreement.CalculateAgreement(clientPub, sharedSecret, 0);
+
+        var salt = new byte[16];
+        rng.NextBytes(salt);
+
+        Span<byte> okm = stackalloc byte[68];
+        var hkdf = new HkdfBytesGenerator(new Sha256Digest());
+        hkdf.Init(new HkdfParameters(sharedSecret, salt, Info));
+        hkdf.GenerateBytes(okm);
+
+        var txKey = okm.Slice(0, 32).ToArray();
+        var rxKey = okm.Slice(32, 32).ToArray();
+        var dirSalt = okm.Slice(64, 4).ToArray();
+
+        return (serverPub, salt, new SecureSession(txKey, rxKey, dirSalt));
+    }
+
+    public static SecureSession CreateAsClient(ReadOnlySpan<byte> clientPrivateKey, ReadOnlySpan<byte> serverPublicKey, ReadOnlySpan<byte> salt)
+    {
+        var clientPriv = new X25519PrivateKeyParameters(clientPrivateKey);
+        var serverPub = new X25519PublicKeyParameters(serverPublicKey);
+        var agreement = new X25519Agreement();
+        agreement.Init(clientPriv);
+        byte[] sharedSecret = new byte[agreement.AgreementSize];
+        agreement.CalculateAgreement(serverPub, sharedSecret, 0);
+
+        Span<byte> okm = stackalloc byte[68];
+        var hkdf = new HkdfBytesGenerator(new Sha256Digest());
+        hkdf.Init(new HkdfParameters(sharedSecret, salt.ToArray(), Info));
+        hkdf.GenerateBytes(okm);
+
+        var rxKey = okm.Slice(0, 32).ToArray();
+        var txKey = okm.Slice(32, 32).ToArray();
+        var dirSalt = okm.Slice(64, 4).ToArray();
+
+        return new SecureSession(txKey, rxKey, dirSalt);
+    }
+
+    public byte[] EncryptPacket(ref Header header, ReadOnlySpan<byte> plain)
+    {
+        header = new Header(header.ConnId, SeqTx, PacketFlagsUtils.AddFlag(header.Flags, PacketFlags.Encrypted), header.ChannelId);
+
+        Span<byte> nonce = stackalloc byte[12];
+        DirSalt.CopyTo(nonce);
+        BinaryPrimitives.WriteUInt64BigEndian(nonce.Slice(4), SeqTx);
+
+        var parameters = new AeadParameters(new KeyParameter(TxKey), 128, nonce.ToArray(), header.ToArray());
+        var cipher = new Org.BouncyCastle.Crypto.Modes.ChaCha20Poly1305();
+        cipher.Init(true, parameters);
+
+        byte[] output = new byte[plain.Length + 16];
+        int len = cipher.ProcessBytes(plain.ToArray(), 0, plain.Length, output, 0);
+        cipher.DoFinal(output, len);
+
+        SeqTx++;
+        return output;
+    }
+
+    public byte[] DecryptPacket(Header header, ReadOnlySpan<byte> cipherText)
+    {
+        if (header.Seq != SeqRx)
+            throw new InvalidOperationException("Invalid sequence");
+
+        Span<byte> nonce = stackalloc byte[12];
+        DirSalt.CopyTo(nonce);
+        BinaryPrimitives.WriteUInt64BigEndian(nonce.Slice(4), SeqRx);
+
+        var parameters = new AeadParameters(new KeyParameter(RxKey), 128, nonce.ToArray(), header.ToArray());
+        var cipher = new Org.BouncyCastle.Crypto.Modes.ChaCha20Poly1305();
+        cipher.Init(false, parameters);
+
+        byte[] output = new byte[cipherText.Length - 16];
+        int len = cipher.ProcessBytes(cipherText.ToArray(), 0, cipherText.Length, output, 0);
+        try
+        {
+            cipher.DoFinal(output, len);
+        }
+        catch (InvalidCipherTextException e)
+        {
+            throw new InvalidOperationException("Invalid authentication tag", e);
+        }
+
+        SeqRx++;
+        return output;
+    }
+}
+

--- a/GameServer.csproj
+++ b/GameServer.csproj
@@ -18,6 +18,7 @@
         <ItemGroup>
           <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
           <PackageReference Include="Spectre.Console" Version="0.50.0" />
+          <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Network/SecureSession.test.cs
+++ b/Tests/Network/SecureSession.test.cs
@@ -1,0 +1,65 @@
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Crypto.Parameters;
+
+namespace Tests
+{
+    public class SecureSessionTests : AbstractTest
+    {
+        public SecureSessionTests()
+        {
+            Describe("SecureSession Handshake", () =>
+            {
+                It("should establish shared keys and exchange messages", () =>
+                {
+                    var rng = new SecureRandom();
+                    var clientPriv = new X25519PrivateKeyParameters(rng);
+                    var clientPub = clientPriv.GeneratePublicKey().GetEncoded();
+
+                    var (serverPub, salt, serverSession) = SecureSession.CreateAsServer(clientPub);
+                    var clientSession = SecureSession.CreateAsClient(clientPriv.GetEncoded(), serverPub, salt);
+
+                    Expect(serverSession.TxKey).ToBeEquivalentTo(clientSession.RxKey);
+                    Expect(serverSession.RxKey).ToBeEquivalentTo(clientSession.TxKey);
+                    Expect(serverSession.DirSalt).ToBeEquivalentTo(clientSession.DirSalt);
+
+                    var header = new Header(1, 0, PacketFlags.Encrypted, 1);
+                    var plain = System.Text.Encoding.UTF8.GetBytes("hello world");
+                    var cipher = serverSession.EncryptPacket(ref header, plain);
+                    var decrypted = clientSession.DecryptPacket(header, cipher);
+                    Expect(System.Text.Encoding.UTF8.GetString(decrypted)).ToBe("hello world");
+
+                    var header2 = new Header(1, 0, PacketFlags.Encrypted, 1);
+                    var cipher2 = clientSession.EncryptPacket(ref header2, plain);
+                    var decrypted2 = serverSession.DecryptPacket(header2, cipher2);
+                    Expect(System.Text.Encoding.UTF8.GetString(decrypted2)).ToBe("hello world");
+                });
+
+                It("should reject tampered packets", () =>
+                {
+                    var rng = new SecureRandom();
+                    var clientPriv = new X25519PrivateKeyParameters(rng);
+                    var clientPub = clientPriv.GeneratePublicKey().GetEncoded();
+
+                    var (serverPub, salt, serverSession) = SecureSession.CreateAsServer(clientPub);
+                    var clientSession = SecureSession.CreateAsClient(clientPriv.GetEncoded(), serverPub, salt);
+
+                    var header = new Header(1, 0, PacketFlags.Encrypted, 1);
+                    var plain = System.Text.Encoding.UTF8.GetBytes("bad");
+                    var cipher = serverSession.EncryptPacket(ref header, plain);
+                    cipher[^1] ^= 0xFF;
+
+                    bool failed = false;
+                    try
+                    {
+                        clientSession.DecryptPacket(header, cipher);
+                    }
+                    catch
+                    {
+                        failed = true;
+                    }
+                    Expect(failed).ToBe(true);
+                });
+            });
+        }
+    }
+}

--- a/Unreal/Source/ToS_Network/Private/Crypto/ChaCha20Poly1305.cpp
+++ b/Unreal/Source/ToS_Network/Private/Crypto/ChaCha20Poly1305.cpp
@@ -1,0 +1,59 @@
+/*
+ * ChaCha20-Poly1305 wrappers
+ *
+ * Author: Andre Ferreira
+ *
+ * Copyright (c) Uzmi Games. Licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Crypto/ChaCha20Poly1305.h"
+#include <sodium.h>
+
+bool UChaCha20Poly1305::ChaCha20Poly1305Ietf_Encrypt(const TArray<uint8>& Key, const TArray<uint8>& Nonce, const TArray<uint8>& AAD, const TArray<uint8>& Plain, TArray<uint8>& Cipher)
+{
+    if (sodium_init() < 0)
+        return false;
+
+    Cipher.SetNumUninitialized(Plain.Num() + crypto_aead_chacha20poly1305_IETF_ABYTES);
+    unsigned long long outLen = 0;
+    int res = crypto_aead_chacha20poly1305_ietf_encrypt(
+        Cipher.GetData(), &outLen,
+        Plain.GetData(), Plain.Num(),
+        AAD.GetData(), AAD.Num(),
+        nullptr,
+        Nonce.GetData(), Key.GetData());
+    return res == 0;
+}
+
+bool UChaCha20Poly1305::ChaCha20Poly1305Ietf_Decrypt(const TArray<uint8>& Key, const TArray<uint8>& Nonce, const TArray<uint8>& AAD, const TArray<uint8>& Cipher, TArray<uint8>& Plain)
+{
+    if (sodium_init() < 0)
+        return false;
+
+    if (Cipher.Num() < crypto_aead_chacha20poly1305_IETF_ABYTES)
+        return false;
+
+    Plain.SetNumUninitialized(Cipher.Num() - crypto_aead_chacha20poly1305_IETF_ABYTES);
+    unsigned long long outLen = 0;
+    int res = crypto_aead_chacha20poly1305_ietf_decrypt(
+        Plain.GetData(), &outLen, nullptr,
+        Cipher.GetData(), Cipher.Num(),
+        AAD.GetData(), AAD.Num(),
+        Nonce.GetData(), Key.GetData());
+    return res == 0;
+}

--- a/Unreal/Source/ToS_Network/Public/Crypto/ChaCha20Poly1305.h
+++ b/Unreal/Source/ToS_Network/Public/Crypto/ChaCha20Poly1305.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "ChaCha20Poly1305.generated.h"
+
+UCLASS()
+class TOS_NETWORK_API UChaCha20Poly1305 : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(BlueprintCallable, Category = "Crypto")
+    static bool ChaCha20Poly1305Ietf_Encrypt(const TArray<uint8>& Key, const TArray<uint8>& Nonce, const TArray<uint8>& AAD, const TArray<uint8>& Plain, TArray<uint8>& Cipher);
+
+    UFUNCTION(BlueprintCallable, Category = "Crypto")
+    static bool ChaCha20Poly1305Ietf_Decrypt(const TArray<uint8>& Key, const TArray<uint8>& Nonce, const TArray<uint8>& AAD, const TArray<uint8>& Cipher, TArray<uint8>& Plain);
+};


### PR DESCRIPTION
## Summary
- Implement secure session with X25519 ECDH and ChaCha20-Poly1305 AEAD
- Add Blueprint-callable wrappers for ChaCha20-Poly1305 in Unreal client
- Add interoperability tests validating key exchange and tamper detection

## Testing
- `pnpm build` *(fails: dotnet not found)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a579c126648333a6b5529238b09cfc