### PR TITLE
Add unsafe ChaCha20-Poly1305 helper

### DIFF
--- a/Core/Network/AeadChaCha.cs
+++ b/Core/Network/AeadChaCha.cs
@@ -1,0 +1,89 @@
+using System.Buffers.Binary;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto;
+
+public static unsafe class AeadChaCha
+{
+    public static bool Seal(SecureSession* s, in NetHeader hdr,
+                            byte* plain, int plainLen,
+                            byte* outBuf, int outCap, out int outLen)
+    {
+        outLen = 0;
+        int need = plainLen + 16;
+        if (outCap < need)
+            return false;
+
+        Span<byte> key = stackalloc byte[32];
+        new Span<byte>(s->TxKey, 32).CopyTo(key);
+        Span<byte> nonce = stackalloc byte[12];
+        new Span<byte>(s->DirSalt, 4).CopyTo(nonce);
+        BinaryPrimitives.WriteUInt64BigEndian(nonce.Slice(4), s->SeqTx);
+
+        Span<byte> aad = new Span<byte>((byte*)&hdr, sizeof(NetHeader));
+        byte[] keyArr = key.ToArray();
+        byte[] nonceArr = nonce.ToArray();
+        byte[] aadArr = aad.ToArray();
+        byte[] plainArr = new byte[plainLen];
+        new Span<byte>(plain, plainLen).CopyTo(plainArr);
+
+        var parameters = new AeadParameters(new KeyParameter(keyArr), 128, nonceArr, aadArr);
+        var cipher = new ChaCha20Poly1305();
+        cipher.Init(true, parameters);
+        byte[] output = new byte[need];
+        int len = cipher.ProcessBytes(plainArr, 0, plainLen, output, 0);
+        cipher.DoFinal(output, len);
+
+        new Span<byte>(output).CopyTo(new Span<byte>(outBuf, need));
+        outLen = need;
+        s->SeqTx++;
+        return true;
+    }
+
+    public static bool Open(SecureSession* s, in NetHeader hdr,
+                            byte* cipherText, int cipherLen,
+                            byte* outBuf, int outCap, out int outLen)
+    {
+        outLen = 0;
+        if (cipherLen < 16)
+            return false;
+        int need = cipherLen - 16;
+        if (outCap < need)
+            return false;
+        if ((uint)s->SeqRx != BinaryPrimitives.ReadUInt32BigEndian(((byte*)&hdr) + 4))
+            return false;
+
+        Span<byte> key = stackalloc byte[32];
+        new Span<byte>(s->RxKey, 32).CopyTo(key);
+        Span<byte> nonce = stackalloc byte[12];
+        new Span<byte>(s->DirSalt, 4).CopyTo(nonce);
+        BinaryPrimitives.WriteUInt64BigEndian(nonce.Slice(4), s->SeqRx);
+        Span<byte> aad = new Span<byte>((byte*)&hdr, sizeof(NetHeader));
+
+        byte[] keyArr = key.ToArray();
+        byte[] nonceArr = nonce.ToArray();
+        byte[] aadArr = aad.ToArray();
+        byte[] cipherArr = new byte[cipherLen];
+        new Span<byte>(cipherText, cipherLen).CopyTo(cipherArr);
+
+        var parameters = new AeadParameters(new KeyParameter(keyArr), 128, nonceArr, aadArr);
+        var cipher = new ChaCha20Poly1305();
+        cipher.Init(false, parameters);
+        byte[] output = new byte[need];
+        int len = cipher.ProcessBytes(cipherArr, 0, cipherLen, output, 0);
+        try
+        {
+            cipher.DoFinal(output, len);
+        }
+        catch (InvalidCipherTextException)
+        {
+            return false;
+        }
+
+        new Span<byte>(output).CopyTo(new Span<byte>(outBuf, need));
+        outLen = need;
+        s->SeqRx++;
+        return true;
+    }
+}
+

--- a/Core/Network/NetHeader.cs
+++ b/Core/Network/NetHeader.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public unsafe struct NetHeader
+{
+    public uint ConnId;
+    public uint Seq32;
+    public ushort Flags;
+    public uint ChannelId;
+    public fixed byte Reserved[2];
+}
+

--- a/Core/Network/SecureSessionUnsafe.cs
+++ b/Core/Network/SecureSessionUnsafe.cs
@@ -1,0 +1,73 @@
+using System.Buffers.Binary;
+using Org.BouncyCastle.Crypto.Agreement;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Utilities;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Crypto;
+
+public unsafe struct SecureSession
+{
+    private static readonly byte[] Info = System.Text.Encoding.ASCII.GetBytes("ToS-UE5 v1");
+
+    public fixed byte TxKey[32];
+    public fixed byte RxKey[32];
+    public fixed byte DirSalt[4];
+    public ulong SeqTx;
+    public ulong SeqRx;
+
+    public static (byte[] serverPublicKey, byte[] salt, SecureSession session) CreateAsServer(ReadOnlySpan<byte> clientPublicKey)
+    {
+        var rng = new SecureRandom();
+        var serverPriv = new X25519PrivateKeyParameters(rng);
+        var serverPub = serverPriv.GeneratePublicKey().GetEncoded();
+
+        var clientPub = new X25519PublicKeyParameters(clientPublicKey);
+        var agreement = new X25519Agreement();
+        agreement.Init(serverPriv);
+        byte[] sharedSecret = new byte[agreement.AgreementSize];
+        agreement.CalculateAgreement(clientPub, sharedSecret, 0);
+
+        var salt = new byte[16];
+        rng.NextBytes(salt);
+
+        Span<byte> okm = stackalloc byte[68];
+        var hkdf = new HkdfBytesGenerator(new Sha256Digest());
+        hkdf.Init(new HkdfParameters(sharedSecret, salt, Info));
+        hkdf.GenerateBytes(okm);
+
+        SecureSession sess = default;
+        okm.Slice(0, 32).CopyTo(new Span<byte>(sess.TxKey, 32));
+        okm.Slice(32, 32).CopyTo(new Span<byte>(sess.RxKey, 32));
+        okm.Slice(64, 4).CopyTo(new Span<byte>(sess.DirSalt, 4));
+        sess.SeqTx = 0;
+        sess.SeqRx = 0;
+
+        return (serverPub, salt, sess);
+    }
+
+    public static SecureSession CreateAsClient(ReadOnlySpan<byte> clientPrivateKey, ReadOnlySpan<byte> serverPublicKey, ReadOnlySpan<byte> salt)
+    {
+        var clientPriv = new X25519PrivateKeyParameters(clientPrivateKey);
+        var serverPub = new X25519PublicKeyParameters(serverPublicKey);
+        var agreement = new X25519Agreement();
+        agreement.Init(clientPriv);
+        byte[] sharedSecret = new byte[agreement.AgreementSize];
+        agreement.CalculateAgreement(serverPub, sharedSecret, 0);
+
+        Span<byte> okm = stackalloc byte[68];
+        var hkdf = new HkdfBytesGenerator(new Sha256Digest());
+        hkdf.Init(new HkdfParameters(sharedSecret, salt.ToArray(), Info));
+        hkdf.GenerateBytes(okm);
+
+        SecureSession sess = default;
+        okm.Slice(32, 32).CopyTo(new Span<byte>(sess.TxKey, 32));
+        okm.Slice(0, 32).CopyTo(new Span<byte>(sess.RxKey, 32));
+        okm.Slice(64, 4).CopyTo(new Span<byte>(sess.DirSalt, 4));
+        sess.SeqTx = 0;
+        sess.SeqRx = 0;
+        return sess;
+    }
+}
+

--- a/Tests/Network/AeadChaCha.test.cs
+++ b/Tests/Network/AeadChaCha.test.cs
@@ -1,0 +1,84 @@
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Crypto.Parameters;
+
+namespace Tests
+{
+    public unsafe class AeadChaChaTests : AbstractTest
+    {
+        public AeadChaChaTests()
+        {
+            Describe("AeadChaCha", () =>
+            {
+                It("should encrypt and decrypt", () =>
+                {
+                    var rng = new SecureRandom();
+                    var clientPriv = new X25519PrivateKeyParameters(rng);
+                    var clientPub = clientPriv.GeneratePublicKey().GetEncoded();
+
+                    var (serverPub, salt, serverSession) = SecureSession.CreateAsServer(clientPub);
+                    var clientSession = SecureSession.CreateAsClient(clientPriv.GetEncoded(), serverPub, salt);
+
+                    NetHeader hdr = new NetHeader { ConnId = 1, Seq32 = 0, Flags = 1, ChannelId = 1 };
+                    byte[] plain = System.Text.Encoding.UTF8.GetBytes("hello");
+                    byte[] cipher = new byte[plain.Length + 16];
+
+                    fixed (SecureSession* sPtr = &serverSession)
+                    fixed (byte* plainPtr = plain)
+                    fixed (byte* cipherPtr = cipher)
+                    {
+                        bool ok = AeadChaCha.Seal(sPtr, hdr, plainPtr, plain.Length, cipherPtr, cipher.Length, out int outLen);
+                        Expect(ok).ToBe(true);
+                        Expect(outLen).ToBe(cipher.Length);
+                    }
+
+                    byte[] decrypted = new byte[plain.Length];
+                    fixed (SecureSession* cPtr = &clientSession)
+                    fixed (byte* cipherPtr = cipher)
+                    fixed (byte* decPtr = decrypted)
+                    {
+                        bool ok = AeadChaCha.Open(cPtr, hdr, cipherPtr, cipher.Length, decPtr, decrypted.Length, out int outLen);
+                        Expect(ok).ToBe(true);
+                        Expect(outLen).ToBe(decrypted.Length);
+                    }
+
+                    Expect(System.Text.Encoding.UTF8.GetString(decrypted)).ToBe("hello");
+                });
+
+                It("should reject tampered packets", () =>
+                {
+                    var rng = new SecureRandom();
+                    var clientPriv = new X25519PrivateKeyParameters(rng);
+                    var clientPub = clientPriv.GeneratePublicKey().GetEncoded();
+
+                    var (serverPub, salt, serverSession) = SecureSession.CreateAsServer(clientPub);
+                    var clientSession = SecureSession.CreateAsClient(clientPriv.GetEncoded(), serverPub, salt);
+
+                    NetHeader hdr = new NetHeader { ConnId = 1, Seq32 = 0, Flags = 1, ChannelId = 1 };
+                    byte[] plain = System.Text.Encoding.UTF8.GetBytes("bad");
+                    byte[] cipher = new byte[plain.Length + 16];
+
+                    fixed (SecureSession* sPtr = &serverSession)
+                    fixed (byte* plainPtr = plain)
+                    fixed (byte* cipherPtr = cipher)
+                    {
+                        AeadChaCha.Seal(sPtr, hdr, plainPtr, plain.Length, cipherPtr, cipher.Length, out int _);
+                    }
+
+                    cipher[^1] ^= 0xFF;
+
+                    byte[] decrypted = new byte[plain.Length];
+                    bool ok;
+                    fixed (SecureSession* cPtr = &clientSession)
+                    fixed (byte* cipherPtr = cipher)
+                    fixed (byte* decPtr = decrypted)
+                    {
+                        ok = AeadChaCha.Open(cPtr, hdr, cipherPtr, cipher.Length, decPtr, decrypted.Length, out int _);
+                    }
+
+                    Expect(ok).ToBe(false);
+                });
+            });
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Define NetHeader and SecureSession structs with fixed buffers
- Add AeadChaCha helper for sealing and opening packets
- Cover ChaCha20-Poly1305 roundtrip and tamper cases in tests

## Testing
- `pnpm build` *(fails: dotnet: not found)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57db4b8ac83338e4291ce5f47c258