### PR TITLE
Add byte array support to contracts and FlatBuffer

### DIFF
--- a/Contract/NetworkContracts.cs
+++ b/Contract/NetworkContracts.cs
@@ -18,10 +18,10 @@ public partial struct ConnectionAcceptedPacket
     [ContractField("uint")]
     public uint Id;
 
-    [ContractField("byte[]")]
+    [ContractField("byte[]", 32)]
     public byte[] ServerPublicKey;
 
-    [ContractField("byte[]")]
+    [ContractField("byte[]", 16)]
     public byte[] Salt;
 }
 

--- a/Core/Decorators/ContractDecorators.cs
+++ b/Core/Decorators/ContractDecorators.cs
@@ -77,9 +77,11 @@ public class ContractAttribute : Attribute
 public class ContractFieldAttribute : Attribute
 {
     public string Type { get; }
+    public int ByteCount { get; }
 
-    public ContractFieldAttribute(string type)
+    public ContractFieldAttribute(string type, int byteCount = 0)
     {
         Type = type;
+        ByteCount = byteCount;
     }
 }

--- a/Core/Network/FlatBuffer.cs
+++ b/Core/Network/FlatBuffer.cs
@@ -22,6 +22,7 @@
 * SOFTWARE.
 */
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -138,6 +139,32 @@ public unsafe struct FlatBuffer : IDisposable
         T val = *(T*)(_ptr + _offset);
         _offset += size;
         return val;
+    }
+
+    public void WriteBytes(byte[] value)
+    {
+        int len = value.Length;
+
+        if (_offset + len > _capacity)
+            return;
+
+        fixed (byte* src = value)
+        {
+            Buffer.MemoryCopy(src, _ptr + _offset, _capacity - _offset, len);
+        }
+
+        _offset += len;
+    }
+
+    public byte[] ReadBytes(int length)
+    {
+        if (_offset + length > _capacity)
+            throw new IndexOutOfRangeException($"Read exceeds buffer size ({_capacity}) at {_offset} with size {length}");
+
+        byte[] value = new byte[length];
+        Marshal.Copy((IntPtr)(_ptr + _offset), value, 0, length);
+        _offset += length;
+        return value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Packets/ConnectionAcceptedPacket.cs
+++ b/Core/Packets/ConnectionAcceptedPacket.cs
@@ -4,22 +4,22 @@ using System.Runtime.CompilerServices;
 
 public partial struct ConnectionAcceptedPacket: INetworkPacket
 {
-    public int Size => 5;
+    public int Size => 53;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Serialize(ref FlatBuffer buffer)
     {
         buffer.Write(PacketType.ConnectionAccepted);
         buffer.Write(Id);
-        // Unsupported type: byte[]
-        // Unsupported type: byte[]
+        buffer.WriteBytes(ServerPublicKey);
+        buffer.WriteBytes(Salt);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Deserialize(ref FlatBuffer buffer)
     {
         Id = buffer.Read<uint>();
-        // Unsupported type: byte[]
-        // Unsupported type: byte[]
+        ServerPublicKey = buffer.ReadBytes(32);
+        Salt = buffer.ReadBytes(16);
     }
 }

--- a/Core/Transpilers/ContractTranspiler.cs
+++ b/Core/Transpilers/ContractTranspiler.cs
@@ -173,6 +173,8 @@ public class ContractTranspiler : AbstractTranspiler
                     case "fvector":
                     case "frotator":
                         totalBytes += 6; break; // quantized (assumed)
+                    case "byte[]":
+                        totalBytes += fieldAttr?.ByteCount ?? 0; break;
                     default:
                         // unknown: skip size increment
                         break;
@@ -229,6 +231,9 @@ public class ContractTranspiler : AbstractTranspiler
                         case "id":
                             writer.WriteLine($"        buffer.Write(Base36.ToInt({fieldName}));");
                             break;
+                        case "byte[]":
+                            writer.WriteLine($"        buffer.WriteBytes({fieldName});");
+                            break;
                         default:
                             writer.WriteLine($"        // Unsupported type: {fieldType}");
                             break;
@@ -278,6 +283,8 @@ public class ContractTranspiler : AbstractTranspiler
                         writer.WriteLine($"        {fieldName} = buffer.ReadFRotator(0.1f);"); break;
                     case "id":
                         writer.WriteLine($"        {fieldName} = Base36.ToString(buffer.Read<int>());"); break;
+                    case "byte[]":
+                        writer.WriteLine($"        {fieldName} = buffer.ReadBytes({fieldAttr?.ByteCount ?? 0});"); break;
                     default:
                         writer.WriteLine($"        // Unsupported type: {fieldType}"); break;
                 }

--- a/Unreal/Source/ToS_Network/Private/Network/UFlatBuffer.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/UFlatBuffer.cpp
@@ -275,6 +275,21 @@ void UFlatBuffer::WriteBytes(const uint8* Source, int32 Length)
     Position += Length;
 }
 
+void UFlatBuffer::ReadBytes(uint8* Dest, int32 Length)
+{
+    if (!Dest || Length <= 0)
+        return;
+
+    if (Position + Length > Capacity)
+    {
+        UE_LOG(LogTemp, Error, TEXT("UFlatBuffer::ReadBytes - Buffer underflow. Length: %d"), Length);
+        return;
+    }
+
+    FMemory::Memcpy(Dest, Data + Position, Length);
+    Position += Length;
+}
+
 void UFlatBuffer::WriteUtf8String(const FString& Value)
 {
     WriteString(Value);

--- a/Unreal/Source/ToS_Network/Public/Network/UFlatBuffer.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UFlatBuffer.h
@@ -196,6 +196,7 @@ public:
     FORCEINLINE void RestorePosition(int32 NewPos) { SetPosition(NewPos); }
     FORCEINLINE int32 GetLengthBits() const { return (Position * 8) + WriteBitIndex; }
     void WriteBytes(const uint8* Source, int32 Length);
+    void ReadBytes(uint8* Dest, int32 Length);
 
 	FORCEINLINE uint8* GetData() { return Data; }
 	FORCEINLINE const uint8* GetData() const { return Data; }

--- a/Unreal/Source/ToS_Network/Public/Packets/ConnectionAcceptedPacket.h
+++ b/Unreal/Source/ToS_Network/Public/Packets/ConnectionAcceptedPacket.h
@@ -16,18 +16,20 @@ struct FConnectionAcceptedPacket
     int32 Id;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    TArray<uint8>& ServerPublicKey;
+    TArray<uint8> ServerPublicKey;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    TArray<uint8>& Salt;
+    TArray<uint8> Salt;
 
 
-    int32 GetSize() const { return 5; }
+    int32 GetSize() const { return 53; }
 
     void Deserialize(UFlatBuffer* Buffer)
     {
         Id = static_cast<int32>(Buffer->Read<uint32>());
-    // Unsupported type: byte[]
-    // Unsupported type: byte[]
+        ServerPublicKey.SetNumUninitialized(32);
+        Buffer->ReadBytes(ServerPublicKey.GetData(), 32);
+        Salt.SetNumUninitialized(16);
+        Buffer->ReadBytes(Salt.GetData(), 16);
     }
 };


### PR DESCRIPTION
## Summary
- Allow contracts to specify fixed-length byte arrays via `ContractFieldAttribute`
- Implement `WriteBytes`/`ReadBytes` for FlatBuffer and Unreal UFlatBuffer
- Generate correct serialization for `ConnectionAcceptedPacket` byte arrays

## Testing
- `pnpm build` *(fails: sh: 1: dotnet: not found)*
- `dotnet run --project GameServer.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a5894ac9d08333a21eaf472b0cbe34