### PR TITLE
Log base64 server key and salt for handshake debugging

### DIFF
--- a/Core/Network/UDPServer.cs
+++ b/Core/Network/UDPServer.cs
@@ -452,6 +452,9 @@ public sealed class UDPServer
                                     Salt = salt
                                 });
 
+                                ServerMonitor.Log($"ServerPublicKey: {Convert.ToBase64String(serverPub)}");
+                                ServerMonitor.Log($"Salt: {Convert.ToBase64String(salt)}");
+
                                 newSocket.State = ConnectionState.Connected;
                             }
                         }

--- a/Unreal/Source/ToS_Network/Private/Network/UDPClient.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/UDPClient.cpp
@@ -15,6 +15,7 @@
 
 #include "Packets/PongPacket.h"
 #include <sodium.h>
+#include "Misc/Base64.h"
 
 UDPClient::UDPClient() {}
 UDPClient::~UDPClient() { Disconnect(); }
@@ -236,6 +237,11 @@ void UDPClient::PollIncomingPackets()
                             Salt.SetNumUninitialized(16);
                             for (int32 i = 0; i < 16; ++i)
                                 Salt[i] = Buffer->ReadByte();
+
+                            FString ServerPublicKeyBase64 = FBase64::Encode(ServerPublicKey);
+                            UE_LOG(LogTemp, Log, TEXT("ServerPublicKey: %s"), *ServerPublicKeyBase64);
+                            FString SaltBase64 = FBase64::Encode(Salt);
+                            UE_LOG(LogTemp, Log, TEXT("Salt: %s"), *SaltBase64);
 
                             if (OnConnect)
                                 OnConnect(clientID);


### PR DESCRIPTION
## Summary
- log server's public key and salt in base64 when accepting a connection
- log received server public key and salt on the client for comparison

## Testing
- `pnpm build` *(fails: dotnet not found)*
- `dotnet run --project GameServer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59f4f86a4833387d14385ed47a377