### PR TITLE
Add cookie challenge packet for handshake

### DIFF
--- a/Contract/NetworkContracts.cs
+++ b/Contract/NetworkContracts.cs
@@ -28,6 +28,13 @@ public partial struct ConnectionAcceptedPacket
 [Contract("ConnectionDenied", PacketLayerType.Server, ContractPacketFlags.ToEntity, PacketType.ConnectionDenied)]
 public partial struct ConnectionDeniedPacket { }
 
+[Contract("Cookie", PacketLayerType.Server, ContractPacketFlags.ToEntity, PacketType.Cookie)]
+public partial struct CookiePacket
+{
+    [ContractField("byte[]", 48)]
+    public byte[] Cookie;
+}
+
 [Contract("Disconnect",PacketLayerType.Server, ContractPacketFlags.ToEntity, PacketType.Disconnect)]
 public partial struct DisconnectPacket { }
 

--- a/Core/Network/PacketsUtils.cs
+++ b/Core/Network/PacketsUtils.cs
@@ -34,6 +34,7 @@ public enum PacketType : byte
     CheckIntegrity,
     BenckmarkTest,
     Fragment,
+    Cookie,
     None = 255
 }
 

--- a/Core/Network/UDPServer.cs
+++ b/Core/Network/UDPServer.cs
@@ -426,7 +426,7 @@ public sealed class UDPServer
 
                                 var cookie = CookieManager.GenerateCookie(address);
                                 var helloBuffer = new FlatBuffer(1 + 48);
-                                helloBuffer.Write(PacketType.ConnectionDenied);
+                                helloBuffer.Write(PacketType.Cookie);
                                 helloBuffer.WriteBytes(cookie);
 
                                 var helloLen = helloBuffer.Position;

--- a/Core/Packets/CookiePacket.cs
+++ b/Core/Packets/CookiePacket.cs
@@ -1,0 +1,21 @@
+// This file was generated automatically, please do not change it.
+
+using System.Runtime.CompilerServices;
+
+public partial struct CookiePacket: INetworkPacket
+{
+    public int Size => 49;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Serialize(ref FlatBuffer buffer)
+    {
+        buffer.Write(PacketType.Cookie);
+        buffer.WriteBytes(Cookie);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deserialize(ref FlatBuffer buffer)
+    {
+        Cookie = buffer.ReadBytes(48);
+    }
+}

--- a/Unreal/Source/ToS_Network/Private/Network/UDPClient.cpp
+++ b/Unreal/Source/ToS_Network/Private/Network/UDPClient.cpp
@@ -298,9 +298,9 @@ void UDPClient::PollIncomingPackets()
                         }
                     }
                     break;
-                    case EPacketType::ConnectionDenied:
+                    case EPacketType::Cookie:
                     {
-                        if (BytesRead == 1 + 48 && !bCookieReceived) 
+                        if (BytesRead == 1 + 48 && !bCookieReceived)
                         {
                             ServerCookie.SetNumUninitialized(48);
                             for (int32 i = 0; i < 48; ++i)
@@ -315,19 +315,20 @@ void UDPClient::PollIncomingPackets()
                             int32 BytesSent = 0;
                             Socket->SendTo(ConnectWithCookie.GetData(), ConnectWithCookie.Num(), BytesSent, *RemoteEndpoint);
                         }
-                        else
-                        {
-                            // Actual connection denied
-                            bIsConnected = false;
-                            bIsConnecting = false;
-                            ConnectionStatus = EConnectionStatus::ConnectionFailed;
+                    }
+                    break;
+                    case EPacketType::ConnectionDenied:
+                    {
+                        // Actual connection denied
+                        bIsConnected = false;
+                        bIsConnecting = false;
+                        ConnectionStatus = EConnectionStatus::ConnectionFailed;
 
-                            if (OnConnectDenied)
-                                OnConnectDenied();
+                        if (OnConnectDenied)
+                            OnConnectDenied();
 
-                            StopPacketPollThread();
-                            StartRetryTimer();
-                        }
+                        StopPacketPollThread();
+                        StartRetryTimer();
                     }
                     break;
                     case EPacketType::Disconnect:

--- a/Unreal/Source/ToS_Network/Public/Network/UDPClient.h
+++ b/Unreal/Source/ToS_Network/Public/Network/UDPClient.h
@@ -58,8 +58,11 @@ enum class EPacketType : uint8
     Error               UMETA(DisplayName = "Error"),
     ConnectionDenied    UMETA(DisplayName = "ConnectionDenied"),
     ConnectionAccepted  UMETA(DisplayName = "ConnectionAccepted"),
-    CheckIntegrity      UMETA(DisplayName = "CheckIntegrity")
-};
+    CheckIntegrity      UMETA(DisplayName = "CheckIntegrity"),
+    BenckmarkTest       UMETA(DisplayName = "BenckmarkTest"),
+    Fragment            UMETA(DisplayName = "Fragment"),
+    Cookie              UMETA(DisplayName = "Cookie")
+  };
 
 class FPacketPollRunnable : public FRunnable
 {

--- a/Unreal/Source/ToS_Network/Public/Packets/CookiePacket.h
+++ b/Unreal/Source/ToS_Network/Public/Packets/CookiePacket.h
@@ -1,0 +1,25 @@
+// This file was generated automatically, please do not change it.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Network/UDPClient.h"
+#include "Network/UFlatBuffer.h"
+#include "Network/ServerPackets.h"
+#include "CookiePacket.generated.h"
+
+USTRUCT(BlueprintType)
+struct FCookiePacket
+{
+    GENERATED_USTRUCT_BODY();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    TArray<uint8> Cookie;
+
+    int32 GetSize() const { return 49; }
+
+    void Deserialize(UFlatBuffer* Buffer)
+    {
+        Cookie.SetNumUninitialized(48);
+        Buffer->ReadBytes(Cookie.GetData(), 48);
+    }
+};


### PR DESCRIPTION
## Summary
- add Cookie packet and enum for anti-spoof handshake
- send cookie challenge from server using Cookie packet
- handle Cookie packet on Unreal client instead of ConnectionDenied

## Testing
- `pnpm build` *(fails: sh: 1: dotnet: not found)*
- `dotnet run --project GameServer.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a630c0cad48333840ec9d0571c0c45